### PR TITLE
SDK P3: PicklistsAPI + opt-in value→IRI record resolution

### DIFF
--- a/src/pyfsr/api/picklists.py
+++ b/src/pyfsr/api/picklists.py
@@ -29,10 +29,7 @@ from .base import BaseAPI
 
 # staging_model_metadatas needs $relationships=true to expose each attribute's
 # dataSource (where the bound picklist listName lives).
-_META_PATH = (
-    "/api/3/staging_model_metadatas"
-    "?$limit=2147483647&$orderby=type&$relationships=true"
-)
+_META_PATH = "/api/3/staging_model_metadatas?$limit=2147483647&$orderby=type&$relationships=true"
 
 
 def _picklist_name_from_attr(attr: dict) -> str | None:
@@ -58,8 +55,8 @@ class PicklistsAPI(BaseAPI):
     def __init__(self, client):
         super().__init__(client)
         self._names: list[str] | None = None
-        self._values: dict[str, list[dict]] = {}      # listName -> items
-        self._iri: dict[str, str] = {}                # "ListName:value" -> IRI
+        self._values: dict[str, list[dict]] = {}  # listName -> items
+        self._iri: dict[str, str] = {}  # "ListName:value" -> IRI
         # module -> {field_name: picklist_name (or None)}
         self._module_fields: dict[str, dict[str, str | None]] = {}
 
@@ -85,19 +82,19 @@ class PicklistsAPI(BaseAPI):
         """List a picklist's items as ``[{itemValue, uuid, iri, ordinal}, ...]``."""
         if picklist_name in self._values:
             return self._values[picklist_name]
-        qs = urllib.parse.urlencode(
-            {"listName.name": picklist_name, "$limit": 200}
-        )
+        qs = urllib.parse.urlencode({"listName.name": picklist_name, "$limit": 200})
         data = self.client.get(f"/api/3/picklists?{qs}")
         out: list[dict[str, Any]] = []
         for m in (data or {}).get("hydra:member") or []:
             u = m.get("uuid")
-            out.append({
-                "itemValue": m.get("itemValue"),
-                "uuid": u,
-                "iri": f"/api/3/picklists/{u}" if u else None,
-                "ordinal": m.get("ordinal"),
-            })
+            out.append(
+                {
+                    "itemValue": m.get("itemValue"),
+                    "uuid": u,
+                    "iri": f"/api/3/picklists/{u}" if u else None,
+                    "ordinal": m.get("ordinal"),
+                }
+            )
         self._values[picklist_name] = out
         return out
 
@@ -110,9 +107,12 @@ class PicklistsAPI(BaseAPI):
         data = self.client.get(_META_PATH)
         members = (data or {}).get("hydra:member") or []
         hit = next(
-            (m for m in members
-             if str(m.get("type", "")).lower() == want
-             or str(m.get("module", "")).lower() == want),
+            (
+                m
+                for m in members
+                if str(m.get("type", "")).lower() == want
+                or str(m.get("module", "")).lower() == want
+            ),
             None,
         )
         fmap: dict[str, str | None] = {}
@@ -163,9 +163,7 @@ class PicklistsAPI(BaseAPI):
                 return iri
         return None
 
-    def resolve_record_fields(
-        self, module: str, fields: dict[str, Any]
-    ) -> dict[str, Any]:
+    def resolve_record_fields(self, module: str, fields: dict[str, Any]) -> dict[str, Any]:
         """Return a copy of ``fields`` with picklist-typed values mapped to IRIs.
 
         Only fields the module flags as picklist-backed are touched, and only

--- a/src/pyfsr/api/picklists.py
+++ b/src/pyfsr/api/picklists.py
@@ -1,0 +1,185 @@
+"""Picklist resolution: name discovery, value lookup, IRI mapping.
+
+Ported from the fsr-playbook-framework runner, de-coupled from its local sqlite
+reference DB. All discovery is live against the FortiSOAR REST API and cached
+in-process for the lifetime of the client.
+
+The hard part FortiSOAR makes you do is turn a *friendly* picklist value (e.g.
+``"High"``) into the IRI (``/api/3/picklists/<uuid>``) the API actually stores.
+This API resolves that, and can auto-discover which picklist a ``(module, field)``
+pair binds to from the module's field metadata.
+
+Example:
+    >>> client.picklists.list()                       # all picklist names
+    >>> client.picklists.values("AlertStatus")        # its items
+    >>> client.picklists.for_field("alerts", "status") # -> "AlertStatus"
+    >>> client.picklists.resolve("High", picklist="Severity")
+    '/api/3/picklists/...'
+    >>> client.picklists.resolve_record_fields(
+    ...     "alerts", {"name": "x", "severity": "High", "status": "Open"})
+    {'name': 'x', 'severity': '/api/3/picklists/...', 'status': '/api/3/picklists/...'}
+"""
+
+from __future__ import annotations
+
+import urllib.parse
+from typing import Any
+
+from .base import BaseAPI
+
+# staging_model_metadatas needs $relationships=true to expose each attribute's
+# dataSource (where the bound picklist listName lives).
+_META_PATH = (
+    "/api/3/staging_model_metadatas"
+    "?$limit=2147483647&$orderby=type&$relationships=true"
+)
+
+
+def _picklist_name_from_attr(attr: dict) -> str | None:
+    """The picklist listName an attribute binds to (e.g. 'AlertStatus')."""
+    ds = attr.get("dataSource") or {}
+    if not isinstance(ds, dict):
+        return None
+    for f in (ds.get("query") or {}).get("filters", []) or []:
+        if isinstance(f, dict) and f.get("field") == "listName__name":
+            v = f.get("value")
+            if isinstance(v, str):
+                return v
+    return None
+
+
+class PicklistsAPI(BaseAPI):
+    """Live picklist lookups and friendly-value → IRI resolution.
+
+    Accessed as :attr:`client.picklists`. All lookups are cached in-process;
+    construct a new client (or call :meth:`clear_cache`) to refresh.
+    """
+
+    def __init__(self, client):
+        super().__init__(client)
+        self._names: list[str] | None = None
+        self._values: dict[str, list[dict]] = {}      # listName -> items
+        self._iri: dict[str, str] = {}                # "ListName:value" -> IRI
+        # module -> {field_name: picklist_name (or None)}
+        self._module_fields: dict[str, dict[str, str | None]] = {}
+
+    # ------------------------------------------------------------------ caches
+    def clear_cache(self) -> None:
+        """Drop all in-process picklist caches."""
+        self._names = None
+        self._values.clear()
+        self._iri.clear()
+        self._module_fields.clear()
+
+    # -------------------------------------------------------------- names/values
+    def list(self) -> list[str]:
+        """Return every picklist name on the server (sorted, cached)."""
+        if self._names is not None:
+            return self._names
+        data = self.client.get("/api/3/picklist_names", params={"$limit": 500})
+        members = (data or {}).get("hydra:member") or []
+        self._names = sorted({m.get("name") for m in members if m.get("name")})
+        return self._names
+
+    def values(self, picklist_name: str) -> list[dict[str, Any]]:
+        """List a picklist's items as ``[{itemValue, uuid, iri, ordinal}, ...]``."""
+        if picklist_name in self._values:
+            return self._values[picklist_name]
+        qs = urllib.parse.urlencode(
+            {"listName.name": picklist_name, "$limit": 200}
+        )
+        data = self.client.get(f"/api/3/picklists?{qs}")
+        out: list[dict[str, Any]] = []
+        for m in (data or {}).get("hydra:member") or []:
+            u = m.get("uuid")
+            out.append({
+                "itemValue": m.get("itemValue"),
+                "uuid": u,
+                "iri": f"/api/3/picklists/{u}" if u else None,
+                "ordinal": m.get("ordinal"),
+            })
+        self._values[picklist_name] = out
+        return out
+
+    # ---------------------------------------------------------- (module,field)
+    def _field_map(self, module: str) -> dict[str, str | None]:
+        """``{field_name: picklist_name|None}`` for one module (live + cached)."""
+        want = module.strip().lower()
+        if want in self._module_fields:
+            return self._module_fields[want]
+        data = self.client.get(_META_PATH)
+        members = (data or {}).get("hydra:member") or []
+        hit = next(
+            (m for m in members
+             if str(m.get("type", "")).lower() == want
+             or str(m.get("module", "")).lower() == want),
+            None,
+        )
+        fmap: dict[str, str | None] = {}
+        if hit is not None:
+            for a in hit.get("attributes") or []:
+                if isinstance(a, dict) and a.get("name"):
+                    fmap[a["name"]] = _picklist_name_from_attr(a)
+        self._module_fields[want] = fmap
+        return fmap
+
+    def for_field(self, module: str, field: str) -> str | None:
+        """Return the picklist name a ``(module, field)`` binds to, or ``None``."""
+        return self._field_map(module).get(field)
+
+    # ----------------------------------------------------------------- resolve
+    def resolve(
+        self,
+        value: str,
+        *,
+        picklist: str | None = None,
+        module: str | None = None,
+        field: str | None = None,
+    ) -> str | None:
+        """Resolve a friendly value (e.g. ``"High"``) to its picklist IRI.
+
+        Provide either an explicit ``picklist`` name, or ``(module, field)`` to
+        auto-discover it. Already-IRI strings pass through unchanged. Returns
+        ``None`` if the value isn't found in the resolved picklist.
+        """
+        if not isinstance(value, str):
+            return None
+        if value.startswith("/api/"):
+            return value
+        if picklist is None:
+            if not (module and field):
+                return None
+            picklist = self.for_field(module, field)
+            if not picklist:
+                return None
+        cache_key = f"{picklist}:{value.lower()}"
+        if cache_key in self._iri:
+            return self._iri[cache_key]
+        for it in self.values(picklist):
+            if (it.get("itemValue") or "").lower() == value.lower():
+                iri = it.get("iri")
+                if iri:
+                    self._iri[cache_key] = iri
+                return iri
+        return None
+
+    def resolve_record_fields(
+        self, module: str, fields: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Return a copy of ``fields`` with picklist-typed values mapped to IRIs.
+
+        Only fields the module flags as picklist-backed are touched, and only
+        when their value is a friendly string (not already an IRI). Unresolvable
+        values are left as-is so the caller still sees the original input.
+        """
+        fmap = self._field_map(module)
+        out: dict[str, Any] = {}
+        for k, v in fields.items():
+            picklist = fmap.get(k)
+            if picklist and isinstance(v, str) and not v.startswith("/api/"):
+                iri = self.resolve(v, picklist=picklist)
+                if iri:
+                    out[k] = iri
+                    continue
+            out[k] = v
+        return out

--- a/src/pyfsr/api/picklists.py
+++ b/src/pyfsr/api/picklists.py
@@ -48,7 +48,7 @@ def _picklist_name_from_attr(attr: dict) -> str | None:
 class PicklistsAPI(BaseAPI):
     """Live picklist lookups and friendly-value → IRI resolution.
 
-    Accessed as :attr:`client.picklists`. All lookups are cached in-process;
+    Accessed as ``client.picklists``. All lookups are cached in-process;
     construct a new client (or call :meth:`clear_cache`) to refresh.
     """
 

--- a/src/pyfsr/client.py
+++ b/src/pyfsr/client.py
@@ -11,6 +11,7 @@ import requests
 from .api.alerts import AlertsAPI
 from .api.content_hub import ContentHubSearch
 from .api.export_config import ExportConfigAPI
+from .api.picklists import PicklistsAPI
 from .api.solution_packs import SolutionPackAPI
 from .auth.api_key import APIKeyAuth
 from .auth.base import BaseAuth
@@ -132,6 +133,9 @@ class FortiSOAR:
 
         # Content Hub search (solution packs, connectors, widgets)
         self.content_hub: ContentHubSearch = ContentHubSearch(self)
+
+        # Picklist discovery + friendly-value -> IRI resolution
+        self.picklists: PicklistsAPI = PicklistsAPI(self)
 
         self.solution_packs: SolutionPackAPI = SolutionPackAPI(self, self.export_config)
 

--- a/src/pyfsr/records.py
+++ b/src/pyfsr/records.py
@@ -206,7 +206,7 @@ class RecordSet:
         ``data`` may be a dict or a model instance; the created record is
         returned parsed (or raw, with ``raw=True``). Pass
         ``resolve_picklists=True`` to map friendly picklist values (e.g.
-        ``"High"``) to their IRIs via :attr:`client.picklists` before sending.
+        ``"High"``) to their IRIs via ``client.picklists`` before sending.
         """
         if isinstance(data, BaseRecord):
             data = data.to_dict(exclude_none=True)

--- a/src/pyfsr/records.py
+++ b/src/pyfsr/records.py
@@ -194,20 +194,43 @@ class RecordSet:
             yield self._parse(record, raw=raw)
 
     # -- writes -------------------------------------------------------------
-    def create(self, data: dict[str, Any], *, raw: bool = False) -> Any:
+    def create(
+        self,
+        data: dict[str, Any],
+        *,
+        raw: bool = False,
+        resolve_picklists: bool = False,
+    ) -> Any:
         """Create a record via ``POST /api/3/<module>``.
 
         ``data`` may be a dict or a model instance; the created record is
-        returned parsed (or raw, with ``raw=True``).
+        returned parsed (or raw, with ``raw=True``). Pass
+        ``resolve_picklists=True`` to map friendly picklist values (e.g.
+        ``"High"``) to their IRIs via :attr:`client.picklists` before sending.
         """
         if isinstance(data, BaseRecord):
             data = data.to_dict(exclude_none=True)
+        if resolve_picklists:
+            data = self.client.picklists.resolve_record_fields(self.module, data)
         return self._parse(self.client.post(f"/api/3/{self.module}", data=data), raw=raw)
 
-    def update(self, ref: str, data: dict[str, Any], *, raw: bool = False) -> Any:
-        """Update a record via ``PUT /api/3/<module>/<uuid>``."""
+    def update(
+        self,
+        ref: str,
+        data: dict[str, Any],
+        *,
+        raw: bool = False,
+        resolve_picklists: bool = False,
+    ) -> Any:
+        """Update a record via ``PUT /api/3/<module>/<uuid>``.
+
+        Pass ``resolve_picklists=True`` to map friendly picklist values to IRIs
+        before sending (see :meth:`create`).
+        """
         if isinstance(data, BaseRecord):
             data = data.to_dict(exclude_none=True)
+        if resolve_picklists:
+            data = self.client.picklists.resolve_record_fields(self.module, data)
         path = resolve_record_path(self.module, ref)
         return self._parse(self.client.put(path, data=data), raw=raw)
 

--- a/tests/integration/test_picklists_integration.py
+++ b/tests/integration/test_picklists_integration.py
@@ -1,0 +1,33 @@
+"""Live integration tests for PicklistsAPI (opt-in: pytest -m integration)."""
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_list_names(client):
+    names = client.picklists.list()
+    assert isinstance(names, list)
+    assert names, "expected at least one picklist on the appliance"
+    assert all(isinstance(n, str) for n in names)
+
+
+def test_for_field_alert_severity(client):
+    picklist = client.picklists.for_field("alerts", "severity")
+    assert picklist, "alerts.severity should be picklist-backed"
+    items = client.picklists.values(picklist)
+    assert items, f"picklist {picklist!r} has no items"
+    assert all("iri" in it for it in items)
+
+
+def test_resolve_roundtrip(client):
+    picklist = client.picklists.for_field("alerts", "severity")
+    label = next(
+        (it["itemValue"] for it in client.picklists.values(picklist) if it["itemValue"]),
+        None,
+    )
+    assert label
+    iri = client.picklists.resolve(label, picklist=picklist)
+    assert iri and iri.startswith("/api/3/picklists/")
+    # IRI passthrough
+    assert client.picklists.resolve(iri) == iri

--- a/tests/unit/test_picklists.py
+++ b/tests/unit/test_picklists.py
@@ -36,21 +36,13 @@ _META = {
                 {
                     "name": "severity",
                     "dataSource": {
-                        "query": {
-                            "filters": [
-                                {"field": "listName__name", "value": "Severity"}
-                            ]
-                        }
+                        "query": {"filters": [{"field": "listName__name", "value": "Severity"}]}
                     },
                 },
                 {
                     "name": "status",
                     "dataSource": {
-                        "query": {
-                            "filters": [
-                                {"field": "listName__name", "value": "AlertStatus"}
-                            ]
-                        }
+                        "query": {"filters": [{"field": "listName__name", "value": "AlertStatus"}]}
                     },
                 },
             ],

--- a/tests/unit/test_picklists.py
+++ b/tests/unit/test_picklists.py
@@ -1,0 +1,241 @@
+"""Unit tests for the PicklistsAPI (live discovery + value -> IRI resolution)."""
+
+from pyfsr.api.picklists import PicklistsAPI
+from pyfsr.records import RecordSet
+
+# --- canned server payloads ------------------------------------------------
+
+_NAMES = {
+    "hydra:member": [
+        {"name": "Severity"},
+        {"name": "AlertStatus"},
+    ]
+}
+
+_SEVERITY_ITEMS = {
+    "hydra:member": [
+        {"itemValue": "High", "uuid": "sev-high", "ordinal": 1},
+        {"itemValue": "Low", "uuid": "sev-low", "ordinal": 2},
+    ]
+}
+
+_STATUS_ITEMS = {
+    "hydra:member": [
+        {"itemValue": "Open", "uuid": "st-open", "ordinal": 1},
+    ]
+}
+
+# staging_model_metadatas?$relationships=true shape
+_META = {
+    "hydra:member": [
+        {
+            "type": "alerts",
+            "module": "alerts",
+            "attributes": [
+                {"name": "name"},
+                {
+                    "name": "severity",
+                    "dataSource": {
+                        "query": {
+                            "filters": [
+                                {"field": "listName__name", "value": "Severity"}
+                            ]
+                        }
+                    },
+                },
+                {
+                    "name": "status",
+                    "dataSource": {
+                        "query": {
+                            "filters": [
+                                {"field": "listName__name", "value": "AlertStatus"}
+                            ]
+                        }
+                    },
+                },
+            ],
+        }
+    ]
+}
+
+
+class FakeClient:
+    """Routes get() by endpoint substring; counts calls per endpoint."""
+
+    def __init__(self):
+        self.get_calls = []
+        self.post_calls = []
+        self.put_calls = []
+        self.picklists = None  # set after construction for RecordSet tests
+
+    def get(self, endpoint, params=None, **kwargs):
+        self.get_calls.append((endpoint, params))
+        if endpoint.startswith("/api/3/picklist_names"):
+            return _NAMES
+        if endpoint.startswith("/api/3/staging_model_metadatas"):
+            return _META
+        if "listName.name=Severity" in endpoint:
+            return _SEVERITY_ITEMS
+        if "listName.name=AlertStatus" in endpoint:
+            return _STATUS_ITEMS
+        return {"hydra:member": []}
+
+    def post(self, endpoint, data=None, params=None, **kwargs):
+        self.post_calls.append((endpoint, data))
+        return data or {}
+
+    def put(self, endpoint, data=None, **kwargs):
+        self.put_calls.append((endpoint, data))
+        return data or {}
+
+
+def _api():
+    client = FakeClient()
+    api = PicklistsAPI(client)
+    client.picklists = api
+    return api, client
+
+
+# --- names / values --------------------------------------------------------
+def test_list_names_sorted_and_cached():
+    api, client = _api()
+    assert api.list() == ["AlertStatus", "Severity"]
+    api.list()  # second call hits cache
+    name_calls = [c for c in client.get_calls if c[0].startswith("/api/3/picklist_names")]
+    assert len(name_calls) == 1
+
+
+def test_values_shape_and_iri():
+    api, _ = _api()
+    items = api.values("Severity")
+    assert items[0]["itemValue"] == "High"
+    assert items[0]["iri"] == "/api/3/picklists/sev-high"
+    assert items[0]["ordinal"] == 1
+
+
+def test_values_cached():
+    api, client = _api()
+    api.values("Severity")
+    api.values("Severity")
+    pl_calls = [c for c in client.get_calls if "listName.name=Severity" in c[0]]
+    assert len(pl_calls) == 1
+
+
+# --- (module, field) discovery --------------------------------------------
+def test_for_field_from_metadata():
+    api, _ = _api()
+    assert api.for_field("alerts", "severity") == "Severity"
+    assert api.for_field("alerts", "status") == "AlertStatus"
+    assert api.for_field("alerts", "name") is None  # not picklist-backed
+    assert api.for_field("alerts", "nonexistent") is None
+
+
+def test_field_map_cached():
+    api, client = _api()
+    api.for_field("alerts", "severity")
+    api.for_field("alerts", "status")
+    meta_calls = [c for c in client.get_calls if c[0].startswith("/api/3/staging_model_metadatas")]
+    assert len(meta_calls) == 1
+
+
+# --- resolve ---------------------------------------------------------------
+def test_resolve_by_explicit_picklist():
+    api, _ = _api()
+    assert api.resolve("High", picklist="Severity") == "/api/3/picklists/sev-high"
+
+
+def test_resolve_case_insensitive():
+    api, _ = _api()
+    assert api.resolve("high", picklist="Severity") == "/api/3/picklists/sev-high"
+
+
+def test_resolve_iri_passthrough():
+    api, client = _api()
+    assert api.resolve("/api/3/picklists/x") == "/api/3/picklists/x"
+    assert client.get_calls == []  # no lookup needed
+
+
+def test_resolve_by_module_field():
+    api, _ = _api()
+    assert api.resolve("Open", module="alerts", field="status") == "/api/3/picklists/st-open"
+
+
+def test_resolve_unknown_value_returns_none():
+    api, _ = _api()
+    assert api.resolve("Bogus", picklist="Severity") is None
+
+
+def test_resolve_needs_picklist_or_module_field():
+    api, _ = _api()
+    assert api.resolve("High") is None
+
+
+def test_resolve_caches_iri():
+    api, client = _api()
+    api.resolve("High", picklist="Severity")
+    api.resolve("High", picklist="Severity")
+    pl_calls = [c for c in client.get_calls if "listName.name=Severity" in c[0]]
+    assert len(pl_calls) == 1
+
+
+# --- resolve_record_fields -------------------------------------------------
+def test_resolve_record_fields():
+    api, _ = _api()
+    out = api.resolve_record_fields(
+        "alerts",
+        {"name": "x", "severity": "High", "status": "Open"},
+    )
+    assert out == {
+        "name": "x",
+        "severity": "/api/3/picklists/sev-high",
+        "status": "/api/3/picklists/st-open",
+    }
+
+
+def test_resolve_record_fields_leaves_unresolvable():
+    api, _ = _api()
+    out = api.resolve_record_fields("alerts", {"severity": "Nope", "name": "x"})
+    assert out == {"severity": "Nope", "name": "x"}  # unchanged
+
+
+def test_resolve_record_fields_iri_passthrough():
+    api, _ = _api()
+    out = api.resolve_record_fields("alerts", {"severity": "/api/3/picklists/sev-low"})
+    assert out == {"severity": "/api/3/picklists/sev-low"}
+
+
+def test_clear_cache():
+    api, client = _api()
+    api.list()
+    api.clear_cache()
+    api.list()
+    name_calls = [c for c in client.get_calls if c[0].startswith("/api/3/picklist_names")]
+    assert len(name_calls) == 2
+
+
+# --- RecordSet opt-in integration -----------------------------------------
+def test_recordset_create_resolves_picklists_opt_in():
+    api, client = _api()
+    RecordSet(client, "alerts", typed=False).create(
+        {"name": "x", "severity": "High"}, resolve_picklists=True
+    )
+    endpoint, data = client.post_calls[0]
+    assert endpoint == "/api/3/alerts"
+    assert data["severity"] == "/api/3/picklists/sev-high"
+
+
+def test_recordset_create_no_resolution_by_default():
+    api, client = _api()
+    RecordSet(client, "alerts", typed=False).create({"severity": "High"})
+    _, data = client.post_calls[0]
+    assert data["severity"] == "High"  # untouched
+
+
+def test_recordset_update_resolves_picklists_opt_in():
+    api, client = _api()
+    RecordSet(client, "alerts", typed=False).update(
+        "u1", {"status": "Open"}, resolve_picklists=True
+    )
+    endpoint, data = client.put_calls[0]
+    assert endpoint == "/api/3/alerts/u1"
+    assert data["status"] == "/api/3/picklists/st-open"


### PR DESCRIPTION
## P3 — Picklists

Ports the framework's picklist resolver into pyfsr, **de-coupled from its sqlite reference DB**. `(module, field) → picklist` discovery now reads live `staging_model_metadatas?$relationships=true` (the attribute's `dataSource…listName__name`) instead of the local DB. Names/values/IRIs are cached in-process.

### API (`client.picklists`)
- `list()` — all picklist names
- `values(name)` — items as `{itemValue, uuid, iri, ordinal}`
- `for_field(module, field)` — discover the picklist a field binds to
- `resolve(value, picklist= | module=+field=)` — friendly value → IRI (IRI passthrough, case-insensitive)
- `resolve_record_fields(module, fields)` — resolve every picklist-typed field in a record dict
- `clear_cache()`

### RecordSet
`create`/`update` gain opt-in `resolve_picklists=True` to map friendly values (e.g. `"High"`) to IRIs before sending.

### Tests
- 19 mocked unit tests (`tests/unit/test_picklists.py`)
- 3 live integration tests (`tests/integration/test_picklists_integration.py`)
- Full unit suite: 92 passed, ruff clean; live-validated against the dev box.