### PR TITLE
SDK P4: safe deletes + recycle bin

### DIFF
--- a/src/pyfsr/records.py
+++ b/src/pyfsr/records.py
@@ -84,18 +84,22 @@ class RecordSet:
         ref: str,
         *,
         relationships: bool = False,
+        show_deleted: bool = False,
         params: dict[str, Any] | None = None,
         raw: bool = False,
     ) -> Any:
         """Fetch one record by uuid, ``module:uuid`` shorthand, or IRI.
 
         Returns the bound model (or ``BaseRecord``); pass ``raw=True`` for the
-        plain decoded dict.
+        plain decoded dict. Pass ``show_deleted=True`` to read a soft-deleted
+        record from the recycle bin (a plain ``get`` 404s on those).
         """
         path = resolve_record_path(self.module, ref)
         query = dict(params or {})
         if relationships:
             query["$relationships"] = "true"
+        if show_deleted:
+            query["$showDeleted"] = "true"
         return self._parse(self.client.get(path, params=query or None), raw=raw)
 
     def list(
@@ -103,13 +107,19 @@ class RecordSet:
         *,
         limit: int = 30,
         page: int = 1,
+        show_deleted: bool = False,
         params: dict[str, Any] | None = None,
         raw: bool = False,
     ) -> HydraPage:
-        """List records via ``GET /api/3/<module>`` (one page)."""
+        """List records via ``GET /api/3/<module>`` (one page).
+
+        Pass ``show_deleted=True`` to include recycle-bin records.
+        """
         query = dict(params or {})
         query["$limit"] = limit
         query["$page"] = page
+        if show_deleted:
+            query["$showDeleted"] = "true"
         resp = self.client.get(f"/api/3/{self.module}", params=query)
         return self._parse_page(HydraPage.from_response(resp, page=page, limit=limit), raw=raw)
 
@@ -119,6 +129,7 @@ class RecordSet:
         *,
         limit: int = 30,
         page: int = 1,
+        show_deleted: bool = False,
         params: dict[str, Any] | None = None,
         raw: bool = False,
     ) -> HydraPage:
@@ -126,18 +137,28 @@ class RecordSet:
         query = dict(params or {})
         if term:
             query["$search"] = term
-        return self.list(limit=limit, page=page, params=query, raw=raw)
+        return self.list(limit=limit, page=page, show_deleted=show_deleted, params=query, raw=raw)
 
     def query(
-        self, query: Query | dict[str, Any], *, page: int = 1, raw: bool = False
+        self,
+        query: Query | dict[str, Any],
+        *,
+        page: int = 1,
+        show_deleted: bool = False,
+        raw: bool = False,
     ) -> HydraPage:
         """Run a structured query via ``POST /api/query/<module>``.
 
         FortiSOAR paginates this endpoint with the ``$limit``/``$page``/``$search``
         *query params* — the ``limit``/``search`` keys in the body are ignored — so
-        they are lifted out of the body and sent as params.
+        they are lifted out of the body and sent as params. Pass
+        ``show_deleted=True`` to include recycle-bin records (sent both as the
+        ``$showDeleted`` param and the ``showDeleted`` body flag the endpoint wants).
         """
         body, params = self._split_query(query, page=page)
+        if show_deleted:
+            params["$showDeleted"] = "true"
+            body["showDeleted"] = True
         resp = self.client.post(f"/api/query/{self.module}", data=body, params=params)
         page_obj = HydraPage.from_response(resp, page=page, limit=params.get("$limit"))
         return self._parse_page(page_obj, raw=raw)
@@ -169,25 +190,30 @@ class RecordSet:
         *,
         page_size: int = 100,
         max_records: int | None = None,
+        show_deleted: bool = False,
         raw: bool = False,
     ) -> Iterator[Any]:
         """Lazily yield every matching record across all pages.
 
         Uses the structured query endpoint when ``query`` is given, otherwise a
         plain list. The page size overrides any ``limit`` on the query. Yields
-        typed models unless ``raw=True``.
+        typed models unless ``raw=True``. Pass ``show_deleted=True`` to include
+        recycle-bin records.
         """
         if query is None:
 
             def fetch(page: int) -> Any:
-                return self.client.get(
-                    f"/api/3/{self.module}",
-                    params={"$limit": page_size, "$page": page},
-                )
+                params = {"$limit": page_size, "$page": page}
+                if show_deleted:
+                    params["$showDeleted"] = "true"
+                return self.client.get(f"/api/3/{self.module}", params=params)
         else:
 
             def fetch(page: int) -> Any:
                 body, params = self._split_query(query, page=page, page_size=page_size)
+                if show_deleted:
+                    params["$showDeleted"] = "true"
+                    body["showDeleted"] = True
                 return self.client.post(f"/api/query/{self.module}", data=body, params=params)
 
         for record in paginate(fetch, page_size=page_size, max_records=max_records):
@@ -234,12 +260,55 @@ class RecordSet:
         path = resolve_record_path(self.module, ref)
         return self._parse(self.client.put(path, data=data), raw=raw)
 
-    def delete(self, ref: str) -> None:
-        """Soft-delete a record via ``DELETE /api/3/<module>/<uuid>``.
+    def _single_record_path(self, ref: str, *, action: str) -> str:
+        """Resolve ``ref`` to a single-record path, refusing collection-wide refs.
 
-        Hard-delete / recycle-bin restore land in a later phase (safe-delete).
+        Guards against an empty/blank ``ref`` (or one that resolves to the bare
+        ``/api/3/<module>`` collection) ever reaching a destructive endpoint —
+        FortiSOAR has no safe bulk delete here, and an empty body has bitten
+        before by acting collection-wide.
         """
-        self.client.delete(resolve_record_path(self.module, ref))
+        if not isinstance(ref, str) or not ref.strip():
+            raise ValueError(f"{action}() requires a non-empty record reference")
+        path = resolve_record_path(self.module, ref.strip())
+        if path.rstrip("/") in (f"/api/3/{self.module}", "/api/3"):
+            raise ValueError(f"refusing to {action}: {ref!r} does not identify a single record")
+        return path
+
+    def delete(self, ref: str, *, hard: bool = False) -> None:
+        """Delete one record by uuid, ``module:uuid`` shorthand, or IRI.
+
+        Soft-delete (default) moves the record to the recycle bin via
+        ``DELETE /api/3/<module>/<uuid>``. A soft-deleted row keeps reserving
+        *both* its uuid and any unique name, so re-creating with the same name
+        will collide until it's purged or restored; reverse it with
+        :meth:`restore`.
+
+        Pass ``hard=True`` to permanently delete via ``?$hardDelete=true``. This
+        is a single-row, URL-scoped delete; on relationship-parent modules
+        (e.g. ``workflow_collections``) the server cascades to children. There is
+        deliberately no bulk path — an empty/blank ``ref`` raises.
+        """
+        path = self._single_record_path(ref, action="delete")
+        params = {"$hardDelete": "true"} if hard else None
+        self.client.delete(path, params=params)
+
+    def restore(self, ref: str, *, raw: bool = False) -> Any:
+        """Restore a soft-deleted record from the recycle bin.
+
+        Loads the deleted record (``$showDeleted=true``), clears its
+        ``deletedAt``, and PUTs it back. Returns the restored record. Note: via
+        Doctrine cascade-persist this also re-attaches the record's *original*
+        children, even if your current state has since diverged.
+        """
+        path = self._single_record_path(ref, action="restore")
+        current = self.client.get(path, params={"$showDeleted": "true"})
+        if not isinstance(current, dict):
+            raise ValueError(f"could not load deleted record {ref!r} to restore")
+        body = dict(current)
+        body["deletedAt"] = None
+        restored = self.client.put(path, data=body, params={"$showDeleted": "true"})
+        return self._parse(restored, raw=raw)
 
     def __repr__(self) -> str:  # pragma: no cover - debug aid
         return f"RecordSet(module={self.module!r})"

--- a/tests/integration/test_records_integration.py
+++ b/tests/integration/test_records_integration.py
@@ -49,3 +49,47 @@ def test_records_query_pagination_total_stable(client):
     if p1.total is not None and p2.total is not None:
         assert p1.total == p2.total
     assert p2.count >= p1.count
+
+
+# -- P4: safe-delete + recycle lifecycle ------------------------------------
+def test_safe_delete_lifecycle(client):
+    """Create a throwaway alert, delete it, and confirm the record is gone.
+
+    Whether a delete is soft (recycle bin) or permanent is a per-module FSR
+    setting. This test validates the always-true contract — delete removes the
+    record from normal reads — and, *if* the module has a recycle bin, exercises
+    the full ``show_deleted`` → ``restore`` → ``delete(hard=True)`` path.
+    """
+    from pyfsr.exceptions import ResourceNotFoundError
+
+    alerts = client.records("alerts", typed=False)
+    uuid = alerts.create({"name": "pyfsr-p4-safe-delete-test"})["uuid"]
+    recycled_ok = False
+    try:
+        alerts.delete(uuid)  # soft-delete
+        with pytest.raises(ResourceNotFoundError):
+            alerts.get(uuid)  # gone from normal reads either way
+
+        try:
+            recycled = alerts.get(uuid, show_deleted=True)
+        except ResourceNotFoundError:
+            # Module has no recycle bin on this box — delete was permanent.
+            return
+        recycled_ok = True
+        assert recycled["uuid"] == uuid
+        assert recycled.get("deletedAt")  # carries a deletion timestamp
+
+        restored = alerts.restore(uuid)
+        assert restored.get("deletedAt") in (None, "")
+        assert alerts.get(uuid)["uuid"] == uuid  # live again
+    finally:
+        if recycled_ok:
+            alerts.delete(uuid, hard=True)  # permanent cleanup
+            with pytest.raises(ResourceNotFoundError):
+                alerts.get(uuid, show_deleted=True)
+
+
+def test_delete_rejects_blank_ref_live(client):
+    """The single-row guard fires before any network call."""
+    with pytest.raises(ValueError):
+        client.records("alerts").delete("")

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -1,5 +1,7 @@
 """Unit tests for the generic RecordSet CRUD layer."""
 
+import pytest
+
 from pyfsr import Query, RecordSet
 from pyfsr.records import resolve_record_path
 
@@ -19,9 +21,9 @@ class FakeClient:
         self.calls.append(("POST", endpoint, params, data))
         return self._resp(endpoint)
 
-    def put(self, endpoint, data=None, **kwargs):
-        self.calls.append(("PUT", endpoint, None, data))
-        return self._resp(endpoint)
+    def put(self, endpoint, data=None, params=None, **kwargs):
+        self.calls.append(("PUT", endpoint, params, data))
+        return data if data is not None else self._resp(endpoint)
 
     def delete(self, endpoint, params=None, **kwargs):
         self.calls.append(("DELETE", endpoint, params, None))
@@ -148,6 +150,72 @@ def test_delete():
     client = FakeClient()
     RecordSet(client, "alerts").delete("u1")
     assert client.calls[0] == ("DELETE", "/api/3/alerts/u1", None, None)
+
+
+# -- P4: safe deletes + recycle ---------------------------------------------
+def test_hard_delete_sets_param():
+    client = FakeClient()
+    RecordSet(client, "alerts").delete("u1", hard=True)
+    assert client.calls[0] == ("DELETE", "/api/3/alerts/u1", {"$hardDelete": "true"}, None)
+
+
+def test_delete_module_colon_and_iri():
+    client = FakeClient()
+    RecordSet(client, "alerts").delete("incidents:x")
+    RecordSet(client, "alerts").delete("/api/3/alerts/y", hard=True)
+    assert client.calls[0] == ("DELETE", "/api/3/incidents/x", None, None)
+    assert client.calls[1] == ("DELETE", "/api/3/alerts/y", {"$hardDelete": "true"}, None)
+
+
+@pytest.mark.parametrize("bad", ["", "   ", None])
+def test_delete_rejects_blank_ref(bad):
+    client = FakeClient()
+    with pytest.raises(ValueError):
+        RecordSet(client, "alerts").delete(bad)
+    assert client.calls == []  # never reaches the wire
+
+
+def test_restore_clears_deleted_at_and_puts():
+    deleted = {"@id": "/api/3/alerts/u1", "uuid": "u1", "name": "x", "deletedAt": 1234.5}
+    client = FakeClient({"/api/3/alerts/u1": deleted})
+    rec = RecordSet(client, "alerts", typed=False).restore("u1")
+    get_call, put_call = client.calls
+    assert get_call == ("GET", "/api/3/alerts/u1", {"$showDeleted": "true"}, None)
+    method, endpoint, params, data = put_call
+    assert (method, endpoint, params) == ("PUT", "/api/3/alerts/u1", {"$showDeleted": "true"})
+    assert data["deletedAt"] is None
+    assert data["uuid"] == "u1"  # full prior body preserved
+    assert rec["deletedAt"] is None
+
+
+def test_restore_rejects_blank_ref():
+    client = FakeClient()
+    with pytest.raises(ValueError):
+        RecordSet(client, "alerts").restore("")
+
+
+# -- P4: show_deleted plumbing ----------------------------------------------
+def test_get_show_deleted_param():
+    client = FakeClient({"/api/3/alerts/u1": {"uuid": "u1"}})
+    RecordSet(client, "alerts").get("u1", show_deleted=True)
+    assert client.calls[0] == ("GET", "/api/3/alerts/u1", {"$showDeleted": "true"}, None)
+
+
+def test_list_show_deleted_param():
+    client = FakeClient()
+    RecordSet(client, "alerts").list(show_deleted=True)
+    _, endpoint, params, _ = client.calls[0]
+    assert endpoint == "/api/3/alerts"
+    assert params["$showDeleted"] == "true"
+
+
+def test_query_show_deleted_param_and_body():
+    client = FakeClient()
+    RecordSet(client, "alerts").query(Query().limit(5), show_deleted=True)
+    method, endpoint, params, data = client.calls[0]
+    assert method == "POST"
+    assert params["$showDeleted"] == "true"
+    assert data["showDeleted"] is True
 
 
 def test_records_accessor_on_client(mock_client):


### PR DESCRIPTION
## P4 — Safe deletes + recycle

- **`RecordSet.delete(ref, *, hard=False)`** — soft-delete by default (recycle bin); `hard=True` permanently deletes via `?$hardDelete=true`. Single-row, URL-scoped only — a guard refuses blank/collection refs so an empty body can never wildcard-delete (the "purge gone rogue" failure mode).
- **`RecordSet.restore(ref)`** — loads the soft-deleted record (`$showDeleted=true`), clears `deletedAt`, PUTs it back.
- **`show_deleted=`** added to `get` / `list` / `search` / `query` / `iterate` (`$showDeleted` query param; `query`/`iterate` also send the `showDeleted` body flag the query endpoint requires).

### Tests
- Unit tests for every path: hard vs soft delete params, module:uuid/IRI refs, blank-ref guard, restore body/params, and `show_deleted` plumbing across reads. **102 unit pass**, ruff clean, docs `-W -n` clean.
- Adaptive live integration test: validates the always-true delete contract (record gone from normal reads), and the full `show_deleted → restore → hard-delete` path *where the module has a recycle bin enabled*. Live-validated on the dev box.

### Note discovered (out of scope, for a later phase)
On the dev box, the easily-CRUD'd modules (alerts/incidents/tasks) have **no recycle bin** — delete is permanent; only `workflow_collections` recycles. Also surfaced a **pre-existing P2 model bug**: typed `Alert.status`/`severity` are `str` but the live API returns expanded picklist dicts, so `client.records("alerts").list()` (typed) raises a Pydantic `ValidationError`. Tracked for the next phase.