### PR TITLE
Typed models for stable system entities (workflows + content hub)

### DIFF
--- a/src/pyfsr/__init__.py
+++ b/src/pyfsr/__init__.py
@@ -6,7 +6,22 @@ For detailed documentation, visit: https://ftnt-dspille.github.io/pyfsr/
 
 from .client import FortiSOAR
 from .config import EnvConfig
-from .models import MODEL_REGISTRY, Alert, BaseRecord, Comment, Incident, Task, model_for
+from .models import (
+    MODEL_REGISTRY,
+    Alert,
+    BaseRecord,
+    Comment,
+    ContentHubConnector,
+    ContentHubItem,
+    Incident,
+    SolutionPack,
+    Task,
+    Widget,
+    Workflow,
+    WorkflowCollection,
+    WorkflowRun,
+    model_for,
+)
 from .pagination import HydraPage, paginate
 from .projection import SUMMARY_FIELDS, project, project_record, to_jsonable
 from .query import Query
@@ -40,6 +55,13 @@ __all__ = [
     "Incident",
     "Task",
     "Comment",
+    "Workflow",
+    "WorkflowCollection",
+    "WorkflowRun",
+    "ContentHubItem",
+    "SolutionPack",
+    "ContentHubConnector",
+    "Widget",
     "MODEL_REGISTRY",
     "model_for",
     # projection

--- a/src/pyfsr/api/content_hub.py
+++ b/src/pyfsr/api/content_hub.py
@@ -12,10 +12,27 @@ class ContentType(Enum):
     WIDGET = "widget"
 
 
+def _model_for_type(content_type: "ContentType"):
+    """Return the typed model class for a Content Hub ``content_type``."""
+    from ..models import ContentHubConnector, SolutionPack, Widget
+
+    return {
+        ContentType.SOLUTION_PACK: SolutionPack,
+        ContentType.CONNECTOR: ContentHubConnector,
+        ContentType.WIDGET: Widget,
+    }[content_type]
+
+
 class ContentHubSearch(BaseAPI):
     """
     API implementation for searching FortiSOAR Content Hub items including
     solution packs, connectors, and widgets.
+
+    Every search/find method takes an opt-in ``typed=True`` to return the
+    matching typed model (``SolutionPack`` /
+    ``ContentHubConnector`` / ``Widget``).
+    Those models subclass ``BaseRecord`` and stay dict-compatible, so the
+    default (``typed=False``, plain dicts) is unchanged.
     """
 
     def _search_content(
@@ -26,6 +43,7 @@ class ContentHubSearch(BaseAPI):
         limit: int = 30,
         extra_filters: list[dict[str, Any]] | None = None,
         extra_fields: list[str] | None = None,
+        typed: bool = False,
     ) -> list[dict[str, Any]]:
         """
         Generic search method for Content Hub items.
@@ -37,6 +55,10 @@ class ContentHubSearch(BaseAPI):
             limit: Maximum number of results to return
             extra_filters: Additional filters to apply to the query
             extra_fields: Additional fields to include in the response
+            typed: Parse results into the matching typed model
+                (``SolutionPack`` /
+                ``ContentHubConnector`` /
+                ``Widget``). Models stay dict-compatible.
 
         Returns:
             List[Dict[str, Any]]: List of matching content items
@@ -88,64 +110,63 @@ class ContentHubSearch(BaseAPI):
         response = self.client.post(
             f"/api/query/solutionpacks?$limit={limit}&$page=1&$search={search_term}", data=query
         )
-        return response.get("hydra:member", [])
+        members = response.get("hydra:member", [])
+        if typed:
+            model = _model_for_type(content_type)
+            return [model(**m) for m in members]
+        return members
 
     def _find_single_content(
-        self, content_type: ContentType, search_term: str, installed: bool = True
+        self,
+        content_type: ContentType,
+        search_term: str,
+        installed: bool = True,
+        typed: bool = False,
     ) -> dict[str, Any] | None:
         """Find a single content item matching the search criteria."""
         results = self._search_content(
-            content_type=content_type, installed=installed, search_term=search_term, limit=1
+            content_type=content_type,
+            installed=installed,
+            search_term=search_term,
+            limit=1,
+            typed=typed,
         )
         return results[0] if results else None
 
     # Solution Pack Methods
-    def find_installed_pack(self, search_term: str) -> dict[str, Any] | None:
-        """
-        Find a single installed solution pack by name, label, or description.
+    def find_installed_pack(
+        self, search_term: str, *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single installed solution pack by name, label, or description.
 
-        Args:
-            search_term: Name, label, or description to search for
-
-        Returns:
-            Dict[str, Any]: The first matching solution pack object, or None if no matches
+        Pass ``typed=True`` for a ``SolutionPack``.
 
         Example:
             .. code-block:: python
 
                 pack = content_hub.find_installed_pack("SOAR Framework")
         """
-        return self._find_single_content(ContentType.SOLUTION_PACK, search_term, installed=True)
+        return self._find_single_content(
+            ContentType.SOLUTION_PACK, search_term, installed=True, typed=typed
+        )
 
-    def find_available_pack(self, search_term: str = "") -> dict[str, Any] | None:
+    def find_available_pack(
+        self, search_term: str = "", *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single available solution pack by name, label, or description.
+
+        Pass ``typed=True`` for a ``SolutionPack``.
         """
-        Find a single available solution pack by name, label, or description.
-
-        Args:
-            search_term: Name, label, or description to search for
-
-        Returns:
-            Dict[str, Any]: The first matching solution pack object, or None if no matches
-
-        Example:
-            .. code-block:: python
-
-                pack = content_hub.find_available_pack("SOAR Framework")
-        """
-        return self._find_single_content(ContentType.SOLUTION_PACK, search_term, installed=False)
+        return self._find_single_content(
+            ContentType.SOLUTION_PACK, search_term, installed=False, typed=typed
+        )
 
     def search_installed_packs(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all installed solution packs matching the search criteria.
+        """Search for all installed solution packs matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching solution pack objects
+        Pass ``typed=True`` for ``SolutionPack`` objects.
 
         Example:
             .. code-block:: python
@@ -153,224 +174,156 @@ class ContentHubSearch(BaseAPI):
                 packs = content_hub.search_installed_packs("SOAR", limit=10)
         """
         return self._search_content(
-            ContentType.SOLUTION_PACK, installed=True, search_term=search_term, limit=limit
+            ContentType.SOLUTION_PACK,
+            installed=True,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )
 
     def search_available_packs(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all available solution packs matching the search criteria.
+        """Search for all available solution packs matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching solution pack objects
-
-        Example:
-            .. code-block:: python
-
-                packs = content_hub.search_available_packs("SOAR", limit=10)
+        Pass ``typed=True`` for ``SolutionPack`` objects.
         """
         return self._search_content(
-            ContentType.SOLUTION_PACK, installed=False, search_term=search_term, limit=limit
+            ContentType.SOLUTION_PACK,
+            installed=False,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )
 
     # Connector Methods
-    def find_installed_connector(self, search_term: str) -> dict[str, Any] | None:
+    def find_installed_connector(
+        self, search_term: str, *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single installed connector by name, label, or description.
+
+        Pass ``typed=True`` for a ``ContentHubConnector``.
         """
-        Find a single installed connector by name, label, or description.
+        return self._find_single_content(
+            ContentType.CONNECTOR, search_term, installed=True, typed=typed
+        )
 
-        Args:
-            search_term: Name, label, or description to search for
+    def find_available_connector(
+        self, search_term: str = "", *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single available connector by name, label, or description.
 
-        Returns:
-            Dict[str, Any]: The first matching connector object, or None if no matches
-
-        Example:
-            .. code-block:: python
-
-                connector = content_hub.find_installed_connector("OpenAI")
+        Pass ``typed=True`` for a ``ContentHubConnector``.
         """
-        return self._find_single_content(ContentType.CONNECTOR, search_term, installed=True)
+        return self._find_single_content(
+            ContentType.CONNECTOR, search_term, installed=None, typed=typed
+        )
 
-    def find_available_connector(self, search_term: str = "") -> dict[str, Any] | None:
+    def find_uninstalled_connector(
+        self, search_term: str, *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single uninstalled connector by name, label, or description.
+
+        Pass ``typed=True`` for a ``ContentHubConnector``.
         """
-        Find a single available connector by name, label, or description.
-
-        Args:
-            search_term: Name, label, or description to search for
-
-        Returns:
-            Dict[str, Any]: The first matching connector object, or None if no matches
-
-        Example:
-            .. code-block:: python
-
-                connector = content_hub.find_available_connector("OpenAI")
-        """
-        return self._find_single_content(ContentType.CONNECTOR, search_term, installed=None)
-
-    def find_uninstalled_connector(self, search_term: str) -> dict[str, Any] | None:
-        """
-        Find a single uninstalled connector by name, label, or description.
-
-        Args:
-            search_term: Name, label, or description to search for
-
-        Returns:
-            Dict[str, Any]: The first matching connector object, or None if no matches
-
-        Example:
-            .. code-block:: python
-
-                connector = content_hub.find_uninstalled_connector("OpenAI")
-        """
-        return self._find_single_content(ContentType.CONNECTOR, search_term, installed=False)
+        return self._find_single_content(
+            ContentType.CONNECTOR, search_term, installed=False, typed=typed
+        )
 
     def search_installed_connectors(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all installed connectors matching the search criteria.
+        """Search for all installed connectors matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching connector objects
-
-        Example:
-            .. code-block:: python
-
-                connectors = content_hub.search_installed_connectors("OpenAI")
+        Pass ``typed=True`` for ``ContentHubConnector`` objects.
         """
         return self._search_content(
-            ContentType.CONNECTOR, installed=True, search_term=search_term, limit=limit
+            ContentType.CONNECTOR,
+            installed=True,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )
 
     def search_available_connectors(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all available connectors matching the search criteria.
+        """Search for all available connectors matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching connector objects
-
-        Example:
-            .. code-block:: python
-
-                connectors = content_hub.search_available_connectors("OpenAI")
+        Pass ``typed=True`` for ``ContentHubConnector`` objects.
         """
         return self._search_content(
-            ContentType.CONNECTOR, installed=None, search_term=search_term, limit=limit
+            ContentType.CONNECTOR,
+            installed=None,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )
 
     def search_uninstalled_connectors(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all uninstalled connectors matching the search criteria.
+        """Search for all uninstalled connectors matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching connector objects
-
-        Example:
-            .. code-block:: python
-
-                connectors = content_hub.search_uninstalled_connectors("OpenAI")
+        Pass ``typed=True`` for ``ContentHubConnector`` objects.
         """
         return self._search_content(
-            ContentType.CONNECTOR, installed=False, search_term=search_term, limit=limit
+            ContentType.CONNECTOR,
+            installed=False,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )
 
     # Widget Methods
-    def find_installed_widget(self, search_term: str) -> dict[str, Any] | None:
+    def find_installed_widget(
+        self, search_term: str, *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single installed widget by name, label, or description.
+
+        Pass ``typed=True`` for a ``Widget``.
         """
-        Find a single installed widget by name, label, or description.
+        return self._find_single_content(
+            ContentType.WIDGET, search_term, installed=True, typed=typed
+        )
 
-        Args:
-            search_term: Name, label, or description to search for
+    def find_available_widget(
+        self, search_term: str = "", *, typed: bool = False
+    ) -> dict[str, Any] | None:
+        """Find a single available widget by name, label, or description.
 
-        Returns:
-            Dict[str, Any]: The first matching widget object, or None if no matches
-
-        Example:
-            .. code-block:: python
-
-                widget = content_hub.find_installed_widget("Stats")
+        Pass ``typed=True`` for a ``Widget``.
         """
-        return self._find_single_content(ContentType.WIDGET, search_term, installed=True)
-
-    def find_available_widget(self, search_term: str = "") -> dict[str, Any] | None:
-        """
-        Find a single available widget by name, label, or description.
-
-        Args:
-            search_term: Name, label, or description to search for
-
-        Returns:
-            Dict[str, Any]: The first matching widget object, or None if no matches
-
-        Example:
-            .. code-block:: python
-
-                widget = content_hub.find_available_widget("Stats")
-        """
-        return self._find_single_content(ContentType.WIDGET, search_term, installed=False)
+        return self._find_single_content(
+            ContentType.WIDGET, search_term, installed=False, typed=typed
+        )
 
     def search_installed_widgets(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all installed widgets matching the search criteria.
+        """Search for all installed widgets matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching widget objects
-
-        Example:
-            .. code-block:: python
-
-                widgets = content_hub.search_installed_widgets("Stats")
+        Pass ``typed=True`` for ``Widget`` objects.
         """
         return self._search_content(
-            ContentType.WIDGET, installed=True, search_term=search_term, limit=limit
+            ContentType.WIDGET,
+            installed=True,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )
 
     def search_available_widgets(
-        self, search_term: str = "", limit: int = 30
+        self, search_term: str = "", limit: int = 30, *, typed: bool = False
     ) -> list[dict[str, Any]]:
-        """
-        Search for all available widgets matching the search criteria.
+        """Search for all available widgets matching the search criteria.
 
-        Args:
-            search_term: Name, label, or description to search for
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict[str, Any]]: List of matching widget objects
-
-        Example:
-            .. code-block:: python
-
-                widgets = content_hub.search_available_widgets("Stats")
+        Pass ``typed=True`` for ``Widget`` objects.
         """
         return self._search_content(
-            ContentType.WIDGET, installed=False, search_term=search_term, limit=limit
+            ContentType.WIDGET,
+            installed=False,
+            search_term=search_term,
+            limit=limit,
+            typed=typed,
         )

--- a/src/pyfsr/api/playbooks.py
+++ b/src/pyfsr/api/playbooks.py
@@ -86,13 +86,16 @@ class PlaybooksAPI(BaseAPI):
         playbook_uuid: str | None = None,
         limit: int = 20,
         raw: bool = False,
+        typed: bool = False,
     ) -> list[dict[str, Any]]:
         """List recent playbook runs, newest first (live + historical merged).
 
         Scope to one playbook by ``playbook`` (name, resolved to uuid) or
         ``playbook_uuid``. Returns shaped dicts
-        (``{task_id, name, status, error_message, modified, uuid, pk, source}``);
-        pass ``raw=True`` for the full unshaped run records.
+        (``{task_id, name, status, error_message, modified, uuid, pk, source}``)
+        by default; pass ``raw=True`` for the full unshaped run records, or
+        ``typed=True`` for ``WorkflowRun`` objects (parsed
+        from the full records, still dict-compatible). ``typed`` wins over ``raw``.
         """
         extra = ""
         if playbook_uuid or playbook:
@@ -102,13 +105,18 @@ class PlaybooksAPI(BaseAPI):
                     return []
             extra = f"&template_iri=/api/3/workflows/{playbook_uuid}"
         members = self._fetch_runs_both(limit=limit, extra_qs=extra)[:limit]
+        if typed:
+            from ..models import WorkflowRun
+
+            return [WorkflowRun(**m) for m in members]
         return members if raw else [_shape_run(m) for m in members]
 
-    def get(self, run_pk: str, *, raw: bool = False) -> dict[str, Any]:
+    def get(self, run_pk: str, *, raw: bool = False, typed: bool = False) -> dict[str, Any]:
         """Fetch one run by its pk (the trailing id of a run's ``@id``).
 
-        Tries the live table first, then historical. Returns a shaped dict
-        (``raw=True`` for the full record).
+        Tries the live table first, then historical. Returns a shaped dict by
+        default; ``raw=True`` for the full record, or ``typed=True`` for a
+        ``WorkflowRun``. ``typed`` wins over ``raw``.
         """
         if not isinstance(run_pk, str) or not run_pk.strip():
             raise ValueError("get() requires a non-empty run pk")
@@ -123,6 +131,10 @@ class PlaybooksAPI(BaseAPI):
             if isinstance(resp, dict) and resp.get("@id"):
                 source = "historical" if "historical" in path else "live"
                 resp["_source"] = source
+                if typed:
+                    from ..models import WorkflowRun
+
+                    return WorkflowRun(**resp)
                 return resp if raw else _shape_run(resp)
         if last_err is not None:
             raise last_err

--- a/src/pyfsr/models/__init__.py
+++ b/src/pyfsr/models/__init__.py
@@ -10,15 +10,27 @@ without a curated model.
 from __future__ import annotations
 
 from ._generated import Alert, Comment, Incident, Task
+from ._system import (
+    ContentHubConnector,
+    ContentHubItem,
+    SolutionPack,
+    Widget,
+    Workflow,
+    WorkflowCollection,
+    WorkflowRun,
+)
 from .base import BaseRecord
 
 # Module (collection) name → model. Keys are the FortiSOAR plural module slugs
-# used in ``/api/3/<module>`` paths.
+# used in ``/api/3/<module>`` paths. The workflow entries are stable,
+# platform-owned schemas (see ``_system`` and the SDK roadmap §7).
 MODEL_REGISTRY: dict[str, type[BaseRecord]] = {
     "alerts": Alert,
     "incidents": Incident,
     "tasks": Task,
     "comments": Comment,
+    "workflows": Workflow,
+    "workflow_collections": WorkflowCollection,
 }
 
 
@@ -33,6 +45,13 @@ __all__ = [
     "Incident",
     "Task",
     "Comment",
+    "Workflow",
+    "WorkflowCollection",
+    "WorkflowRun",
+    "ContentHubItem",
+    "SolutionPack",
+    "ContentHubConnector",
+    "Widget",
     "MODEL_REGISTRY",
     "model_for",
 ]

--- a/src/pyfsr/models/_system.py
+++ b/src/pyfsr/models/_system.py
@@ -1,0 +1,149 @@
+"""Typed models for FortiSOAR's stable, platform-owned *system* entities.
+
+Unlike user-mutable modules (alerts/incidents, which routinely gain custom
+fields), these entities have **fixed, platform-owned schemas** — playbooks,
+playbook collections, playbook runs, and Content Hub items. That makes them the
+highest-value targets for hard typing (see the SDK roadmap §7).
+
+These are **curated by hand** (live-verified against a dev box), not generated
+from the OpenAPI spec — the curated spec doesn't carry these schemas. Every
+model still subclasses :class:`~pyfsr.models.base.BaseRecord`, so it stays
+dict-compatible and tolerates extra/unknown fields (``extra="allow"``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import BaseRecord
+
+# Relationship / embedded-object fields (createUser, modifyUser, priority, ...)
+# come back as expanded dicts; keep them ``Any`` so the model never breaks.
+
+
+class Workflow(BaseRecord):
+    """A playbook (workflow) record from ``/api/3/workflows/``.
+
+    Stable platform schema. ``collection`` is the IRI of the owning
+    :class:`WorkflowCollection`; ``triggerStep`` the IRI of the start step.
+    """
+
+    name: str | None = None
+    aliasName: str | None = None
+    tag: str | None = None
+    description: str | None = None
+    isActive: bool | None = None
+    debug: bool | None = None
+    singleRecordExecution: bool | None = None
+    remoteExecutableFlag: bool | None = None
+    synchronous: bool | None = None
+    triggerLimit: Any | None = None
+    parameters: list[Any] | None = None
+    lastModifyDate: int | None = None
+    collection: str | None = None
+    triggerStep: str | None = None
+    priority: Any | None = None
+    playbookOrigin: Any | None = None
+    isEditable: bool | None = None
+    isPrivate: bool | None = None
+    createUser: Any | None = None
+    createDate: float | None = None
+    modifyUser: Any | None = None
+    modifyDate: float | None = None
+    deletedAt: Any | None = None
+    importedBy: list[Any] | None = None
+    recordTags: list[Any] | None = None
+    id: int | None = None
+
+
+class WorkflowCollection(BaseRecord):
+    """A playbook collection from ``/api/3/workflow_collections/``.
+
+    The folder that groups playbooks; stable platform schema.
+    """
+
+    name: str | None = None
+    description: str | None = None
+    visible: bool | None = None
+    image: Any | None = None
+    createUser: Any | None = None
+    createDate: float | None = None
+    modifyUser: Any | None = None
+    modifyDate: float | None = None
+    deletedAt: Any | None = None
+    importedBy: list[Any] | None = None
+    recordTags: list[Any] | None = None
+    id: int | None = None
+
+
+class WorkflowRun(BaseRecord):
+    """A playbook *run* record from ``/api/wf/api/(historical-)workflows/``.
+
+    The raw run entity. ``PlaybooksAPI`` also exposes a flattened shape via its
+    default (dict) return; pass ``typed=True`` there to get this model instead.
+    """
+
+    name: str | None = None
+    status: str | None = None
+    created: str | None = None
+    modified: str | None = None
+    parent_wf: Any | None = None
+    tags: str | None = None
+    debug: bool | None = None
+    node_name: str | None = None
+    task_id: str | None = None
+    result: Any | None = None
+
+
+class ContentHubItem(BaseRecord):
+    """Shared base for Content Hub items (solution packs, connectors, widgets).
+
+    Returned by ``client.content_hub`` searches when ``typed=True``. Stable,
+    platform-owned schema (the marketplace catalog shape).
+    """
+
+    name: str | None = None
+    label: str | None = None
+    description: str | None = None
+    type: str | None = None
+    version: str | None = None
+    installed: bool | None = None
+    latestAvailableVersion: str | None = None
+    latestCompatibleVersion: str | None = None
+    fsrMinCompatibility: str | None = None
+    publisher: str | None = None
+    certified: bool | None = None
+    featured: bool | None = None
+    featuredTags: list[Any] | None = None
+    draft: bool | None = None
+    local: bool | None = None
+    development: bool | None = None
+    dependencies: list[Any] | None = None
+    category: list[Any] | None = None
+    iconLarge: str | None = None
+    publishedDate: int | None = None
+    buildNumber: int | None = None
+    configCount: int | None = None
+    status: Any | None = None
+    createUser: Any | None = None
+    createDate: float | None = None
+    modifyUser: Any | None = None
+    modifyDate: float | None = None
+    recordTags: list[Any] | None = None
+    importedBy: list[Any] | None = None
+
+
+class SolutionPack(ContentHubItem):
+    """A Content Hub **solution pack** (``type == "solutionpack"``)."""
+
+
+class ContentHubConnector(ContentHubItem):
+    """A Content Hub **connector** listing (``type == "connector"``).
+
+    Named ``ContentHubConnector`` to avoid clashing with the live
+    ``client.connectors`` (execution) surface — this is the *catalog* entry.
+    """
+
+
+class Widget(ContentHubItem):
+    """A Content Hub **widget** (``type == "widget"``)."""

--- a/tests/integration/test_system_models_integration.py
+++ b/tests/integration/test_system_models_integration.py
@@ -1,0 +1,47 @@
+"""Live integration tests for the stable system-entity models.
+
+Requires a reachable FortiSOAR + examples/config.toml. Deselected by default;
+run with: pytest -m integration
+"""
+
+import pytest
+
+from pyfsr import SolutionPack, Workflow, WorkflowCollection, WorkflowRun
+
+pytestmark = pytest.mark.integration
+
+
+def test_records_workflows_returns_typed_model(client):
+    page = client.records("workflows").list(limit=3)
+    if not page.members:
+        pytest.skip("no workflows on box")
+    for rec in page.members:
+        assert isinstance(rec, Workflow)
+        assert rec.uuid
+    # spot-check a typed field round-trips
+    assert isinstance(page.members[0].isActive, (bool, type(None)))
+
+
+def test_records_workflow_collections_returns_typed_model(client):
+    page = client.records("workflow_collections").list(limit=3)
+    if not page.members:
+        pytest.skip("no workflow_collections on box")
+    assert all(isinstance(r, WorkflowCollection) for r in page.members)
+
+
+def test_playbook_runs_typed(client):
+    runs = client.playbooks.runs(limit=3, typed=True)
+    if not runs:
+        pytest.skip("no playbook runs on box")
+    assert all(isinstance(r, WorkflowRun) for r in runs)
+    assert runs[0].status is not None
+    # dict-compatible access still works
+    assert runs[0]["status"] == runs[0].status
+
+
+def test_content_hub_packs_typed(client):
+    packs = client.content_hub.search_installed_packs(limit=3, typed=True)
+    if not packs:
+        pytest.skip("no installed solution packs on box")
+    assert all(isinstance(p, SolutionPack) for p in packs)
+    assert packs[0].installed is True

--- a/tests/unit/test_system_models.py
+++ b/tests/unit/test_system_models.py
@@ -1,0 +1,181 @@
+"""Unit tests for the stable system-entity models (workflows + content hub)."""
+
+from pyfsr import (
+    BaseRecord,
+    ContentHubConnector,
+    ContentHubItem,
+    RecordSet,
+    SolutionPack,
+    Widget,
+    Workflow,
+    WorkflowCollection,
+    WorkflowRun,
+    model_for,
+)
+from pyfsr.api.content_hub import ContentHubSearch
+from pyfsr.api.playbooks import PlaybooksAPI
+from pyfsr.models import MODEL_REGISTRY
+
+
+class FakeClient:
+    def __init__(self, responses=None):
+        self.calls = []
+        self.responses = responses or {}
+
+    def get(self, endpoint, params=None, **kwargs):
+        self.calls.append(("GET", endpoint, params, None))
+        return self.responses.get(endpoint, {})
+
+    def post(self, endpoint, data=None, params=None, **kwargs):
+        self.calls.append(("POST", endpoint, params, data))
+        return self.responses.get(endpoint, {})
+
+
+# -- registry ---------------------------------------------------------------
+def test_registry_covers_workflow_entities():
+    assert MODEL_REGISTRY["workflows"] is Workflow
+    assert MODEL_REGISTRY["workflow_collections"] is WorkflowCollection
+
+
+def test_model_for_workflows():
+    assert model_for("workflows") is Workflow
+    assert model_for("workflow_collections") is WorkflowCollection
+
+
+# -- Workflow / WorkflowCollection models -----------------------------------
+def test_workflow_typed_fields_and_dict_compat():
+    wf = Workflow.model_validate(
+        {
+            "@id": "/api/3/workflows/wf-1",
+            "uuid": "wf-1",
+            "name": "Block IP",
+            "isActive": True,
+            "collection": "/api/3/workflow_collections/c-1",
+            "createUser": {"@id": "/api/3/people/u-1", "name": "Ann"},  # expanded dict kept (Any)
+        }
+    )
+    assert wf.name == "Block IP"
+    assert wf.isActive is True
+    assert wf.collection == "/api/3/workflow_collections/c-1"
+    assert wf.iri == "/api/3/workflows/wf-1"
+    assert wf["createUser"]["name"] == "Ann"  # dict access + Any kept expanded
+
+
+def test_workflow_preserves_unknown_fields():
+    wf = Workflow.model_validate({"uuid": "wf-1", "somethingNew": 42})
+    assert wf["somethingNew"] == 42
+
+
+def test_workflow_collection_fields():
+    wc = WorkflowCollection.model_validate({"uuid": "c-1", "name": "Phishing", "visible": True})
+    assert wc.name == "Phishing"
+    assert wc.visible is True
+    assert isinstance(wc, BaseRecord)
+
+
+def test_recordset_returns_workflow_model():
+    client = FakeClient({"/api/3/workflows/wf-1": {"uuid": "wf-1", "name": "Block IP"}})
+    rec = RecordSet(client, "workflows").get("wf-1")
+    assert isinstance(rec, Workflow)
+    assert rec.name == "Block IP"
+
+
+def test_recordset_returns_workflow_collection_model():
+    client = FakeClient({"/api/3/workflow_collections/c-1": {"uuid": "c-1", "name": "Phishing"}})
+    rec = RecordSet(client, "workflow_collections").get("c-1")
+    assert isinstance(rec, WorkflowCollection)
+
+
+# -- Content Hub models -----------------------------------------------------
+def test_content_hub_item_hierarchy():
+    assert issubclass(SolutionPack, ContentHubItem)
+    assert issubclass(ContentHubConnector, ContentHubItem)
+    assert issubclass(Widget, ContentHubItem)
+
+
+def test_solution_pack_fields():
+    sp = SolutionPack.model_validate(
+        {"uuid": "p1", "name": "soar-framework", "label": "SOAR", "installed": True, "version": "9"}
+    )
+    assert sp.label == "SOAR"
+    assert sp.installed is True
+    assert sp.version == "9"
+
+
+def test_content_hub_search_typed_returns_models():
+    members = {"hydra:member": [{"name": "openai", "label": "OpenAI", "type": "connector"}]}
+    client = FakeClient({"/api/query/solutionpacks?$limit=30&$page=1&$search=": members})
+    ch = ContentHubSearch(client)
+    out = ch.search_installed_connectors(typed=True)
+    assert len(out) == 1
+    assert isinstance(out[0], ContentHubConnector)
+    assert out[0].label == "OpenAI"
+
+
+def test_content_hub_search_default_returns_dicts():
+    members = {"hydra:member": [{"name": "openai", "label": "OpenAI", "type": "connector"}]}
+    client = FakeClient({"/api/query/solutionpacks?$limit=30&$page=1&$search=": members})
+    ch = ContentHubSearch(client)
+    out = ch.search_installed_connectors()
+    assert out == members["hydra:member"]  # plain dicts, unchanged default
+
+
+def test_content_hub_find_typed_single():
+    members = {"hydra:member": [{"name": "stats", "label": "Stats", "type": "widget"}]}
+    client = FakeClient({"/api/query/solutionpacks?$limit=1&$page=1&$search=Stats": members})
+    ch = ContentHubSearch(client)
+    hit = ch.find_installed_widget("Stats", typed=True)
+    assert isinstance(hit, Widget)
+    assert hit.label == "Stats"
+
+
+# -- WorkflowRun via PlaybooksAPI -------------------------------------------
+_RUN = {
+    "@id": "/api/wf/api/workflows/run-1/",
+    "name": "Block IP",
+    "status": "finished",
+    "modified": "2026-06-08T00:00:00Z",
+    "node_name": "node-a",
+}
+
+
+def test_playbooks_runs_typed_returns_workflowrun():
+    client = FakeClient(
+        {
+            "/api/wf/api/workflows/?format=json&limit=20&ordering=-modified"
+            "&parent_wf__isnull=True": {"hydra:member": [_RUN]},
+        }
+    )
+    runs = PlaybooksAPI(client).runs(typed=True)
+    assert len(runs) == 1
+    assert isinstance(runs[0], WorkflowRun)
+    assert runs[0].status == "finished"
+    assert runs[0].node_name == "node-a"
+
+
+def test_playbooks_runs_default_returns_shaped_dict():
+    client = FakeClient(
+        {
+            "/api/wf/api/workflows/?format=json&limit=20&ordering=-modified"
+            "&parent_wf__isnull=True": {"hydra:member": [_RUN]},
+        }
+    )
+    runs = PlaybooksAPI(client).runs()
+    assert isinstance(runs[0], dict)
+    assert set(runs[0]) == {
+        "task_id",
+        "name",
+        "status",
+        "error_message",
+        "modified",
+        "uuid",
+        "pk",
+        "source",
+    }
+
+
+def test_playbooks_get_typed():
+    client = FakeClient({"/api/wf/api/workflows/run-1/?format=json": _RUN})
+    run = PlaybooksAPI(client).get("run-1", typed=True)
+    assert isinstance(run, WorkflowRun)
+    assert run.name == "Block IP"


### PR DESCRIPTION
Post-release follow-up from the SDK roadmap §7: hard-typed Pydantic models for FortiSOAR's **stable, platform-owned** entities — the highest-value typing targets, distinct from user-mutable alert/incident shapes (which stay lenient by design).

### What's added
- **`models/_system.py`** — curated, live-verified models:
  - `Workflow`, `WorkflowCollection` (playbooks + their collections)
  - `WorkflowRun` (playbook run records)
  - `SolutionPack`, `ContentHubConnector`, `Widget` (shared `ContentHubItem` base)
  - All subclass `BaseRecord`, so they stay **dict-compatible** and tolerate extra/unknown fields (`extra="allow"`).
- **Registry wiring** — `workflows` + `workflow_collections` registered in `MODEL_REGISTRY`, so `client.records("workflows")` / `("workflow_collections")` now return typed objects. Zero API change, fully backward-compatible.
- **Opt-in typing on the consuming surfaces** (defaults unchanged):
  - `PlaybooksAPI.runs(..., typed=True)` / `get(..., typed=True)` → `WorkflowRun`
  - `content_hub.search_*(..., typed=True)` / `find_*(..., typed=True)` → the matching content-hub model

### Why curated (not generated)
The curated OpenAPI spec carries no workflow/content-hub schemas, so these can't come from `gen_models.py`. Field sets were verified live against the dev box. These entities have fixed platform schemas, so hard typing is safe here.

### Verification
- 15 new unit tests (210 total) + 4 new live integration tests (green against the dev box).
- `ruff check` + `ruff format` clean; strict `-W -n` Sphinx docs build green.
- Pre-existing, unrelated integration failures in `test_client_integration.py` (`client.solution_packs.*` — a stale accessor) are untouched by this change.