### PR TITLE
Add fsrpb-migration gap APIs to pyfsr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- `Query.changed()` / `Query.in_all()` and the `changed` / `in_all` trigger-condition
+  operators.
+- `RecordSet.upsert()` and `RecordSet.bulk_upsert()` (insert-or-update via
+  `/api/3/upsert/<module>` and `/api/3/bulkupsert/<module>`).
+- `PlaybooksAPI.get(step_detail=True)` and `PlaybooksAPI.run_env()` for the per-step
+  execution trace + Jinja run-context.
+- `ConnectorsAPI.definition()` / `operations()` / `files()` for connector
+  operation-definition and source-file discovery.
+- `client.wf_tools` (`WfToolsAPI`): server-side Jinja rendering (`render` / `render_raw`)
+  and global ("dynamic") variables (`dynamic_variables` / `dynamic_variable`).
+
 ## [0.2.3] - 2024-01-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-06-15
+
 ### Added
 - `Query.changed()` / `Query.in_all()` and the `changed` / `in_all` trigger-condition
   operators.
@@ -15,6 +17,22 @@ All notable changes to this project will be documented in this file.
   operation-definition and source-file discovery.
 - `client.wf_tools` (`WfToolsAPI`): server-side Jinja rendering (`render` / `render_raw`)
   and global ("dynamic") variables (`dynamic_variables` / `dynamic_variable`).
+- `PicklistsAPI.options(name)` — the valid friendly values of a picklist.
+- `PicklistsAPI.resolve_record_fields(..., strict=, report=)` — actionable feedback
+  on a friendly value that isn't in the picklist: `strict=True` raises
+  `PicklistResolutionError` (new) naming the field/value/valid options; `report=[]`
+  collects misses as `{field, value, picklist, valid_values}` without raising.
+- `ModulesAPI.describe(with_values=)`, `format_module()` / `print_module()`,
+  `search()`, `fields()`, `find_field()` — module/field schema discovery, including
+  each picklist field's accepted friendly vocabulary.
+- `client.modules_admin` (`ModulesAdminAPI`): create modules, add/alter fields, and
+  `publish()` staged schema changes (synchronous by default — tolerates the transient
+  migrate-cycle states and polls until the appliance is ready).
+
+### Changed
+- Error parsing now surfaces Symfony validation bodies (`detail` / `violations` /
+  `title`), not just `message` — previously these collapsed to "Unknown error occurred",
+  hiding the real cause of a 400.
 
 ## [0.2.3] - 2024-01-03
 

--- a/src/pyfsr/api/connectors.py
+++ b/src/pyfsr/api/connectors.py
@@ -133,6 +133,45 @@ class ConnectorsAPI(BaseAPI):
                 }
             raise
 
+    # ------------------------------------------------------------- definition
+    def definition(self, connector: str, *, version: str | None = None) -> dict[str, Any]:
+        """Fetch a connector's full definition (config schema + operations).
+
+        ``POST /api/integration/connectors/<name>/<version>/?format=json`` (the
+        endpoint forbids GET). ``version`` is resolved from the configured
+        connector when omitted. The returned dict includes ``config_schema``,
+        ``configuration``, and ``operations`` (each with ``operation``,
+        ``title``, ``parameters``, ``output_schema``).
+
+        Raises ``ValueError`` if the version can't be resolved.
+        """
+        version = version or self.resolve_version(connector)
+        if not version:
+            raise ValueError(
+                f"{connector!r} is not configured; pass version= to fetch its definition"
+            )
+        return self.client.post(
+            f"/api/integration/connectors/{connector}/{version}/?format=json", data={}
+        )
+
+    def operations(self, connector: str, *, version: str | None = None) -> list[dict[str, Any]]:
+        """List a connector's operations (the ``operations`` of :meth:`definition`).
+
+        Each entry carries ``operation`` (the api name), ``title``,
+        ``description``, ``parameters``, and ``output_schema``.
+        """
+        defn = self.definition(connector, version=version)
+        return defn.get("operations") or []
+
+    def files(self, connector_id: str) -> dict[str, Any]:
+        """Fetch a connector's source files (dev) via
+        ``GET /api/integration/connector/<id>/files/``.
+
+        ``connector_id`` is the connector's dev/install id (the ``id`` field of
+        :meth:`definition`). Dev-only; raises on connectors without file access.
+        """
+        return self.client.get(f"/api/integration/connector/{connector_id}/files/")
+
     # ------------------------------------------------------------- execute
     def execute(
         self,

--- a/src/pyfsr/api/modules.py
+++ b/src/pyfsr/api/modules.py
@@ -90,8 +90,9 @@ class ModulesAPI(BaseAPI):
         self._modules = mods
         return mods
 
-    def describe(self, module: str, *, refresh: bool = False,
-                 with_values: bool = False) -> dict[str, Any]:
+    def describe(
+        self, module: str, *, refresh: bool = False, with_values: bool = False
+    ) -> dict[str, Any]:
         """Describe one module's fields.
 
         Returns ``{module, label, plural, field_count, fields}`` where each field
@@ -227,8 +228,7 @@ class ModulesAPI(BaseAPI):
                 hits.append({"module": mod["type"], "field": f})
         return hits
 
-    def format_module(self, module: str, *, refresh: bool = False,
-                      with_values: bool = True) -> str:
+    def format_module(self, module: str, *, refresh: bool = False, with_values: bool = True) -> str:
         """Return a human-readable description of a module and its fields.
 
         Handy for a quick "print one module as a sample" — e.g.

--- a/src/pyfsr/api/modules.py
+++ b/src/pyfsr/api/modules.py
@@ -249,7 +249,8 @@ class ModulesAPI(BaseAPI):
             req = "yes" if f.get("required") else ""
             pick = f"  [picklist: {f['picklist_name']}]" if f.get("picklist_name") else ""
             lines.append(
-                f"  {str(f['name']):<28} {str(f.get('type')):<18} {req:<4} {f.get('title', '')}{pick}"
+                f"  {str(f['name']):<28} {str(f.get('type')):<18} {req:<4} "
+                f"{f.get('title', '')}{pick}"
             )
             vals = f.get("picklist_values")
             if vals:

--- a/src/pyfsr/api/modules.py
+++ b/src/pyfsr/api/modules.py
@@ -31,6 +31,23 @@ _META_BASE = "/api/3/staging_model_metadatas?$limit=2147483647&$orderby=type"
 _META_FULL = _META_BASE + "&$relationships=true"
 
 
+def _friendly(*candidates: Any) -> str:
+    """Return the first non-empty candidate that isn't a Jinja template.
+
+    Module/field ``displayName`` on a live appliance is often a template like
+    ``{{ name }}`` rather than a human label; skip those in favour of a real
+    ``descriptions.singular`` so search and printing read nicely.
+    """
+    for c in candidates:
+        if c and isinstance(c, str) and "{{" not in c:
+            return c
+    # fall back to the first truthy value even if templated
+    for c in candidates:
+        if c:
+            return str(c)
+    return ""
+
+
 class ModulesAPI(BaseAPI):
     """Live module + field schema discovery (cached in-process)."""
 
@@ -58,7 +75,12 @@ class ModulesAPI(BaseAPI):
         mods = [
             {
                 "type": m.get("type"),
-                "label": m.get("displayName") or m.get("module") or m.get("type"),
+                "label": _friendly(
+                    m.get("displayName"),
+                    (m.get("descriptions") or {}).get("singular"),
+                    m.get("module"),
+                    m.get("type"),
+                ),
                 "plural": m.get("module"),
             }
             for m in members
@@ -68,17 +90,24 @@ class ModulesAPI(BaseAPI):
         self._modules = mods
         return mods
 
-    def describe(self, module: str, *, refresh: bool = False) -> dict[str, Any]:
+    def describe(self, module: str, *, refresh: bool = False,
+                 with_values: bool = False) -> dict[str, Any]:
         """Describe one module's fields.
 
         Returns ``{module, label, plural, field_count, fields}`` where each field
         is ``{name, title, type, required, picklist_name}``. If the module isn't
         found, returns ``{error, available}`` listing the known module types.
         Cached per module.
+
+        ``with_values=True`` additionally resolves each picklist-backed field's
+        valid friendly values into ``picklist_values`` — so an AI authoring a
+        record knows exactly which friendly strings are accepted (e.g. the
+        ``AlertType`` options) before it submits.
         """
         want = module.strip().lower()
         if not refresh and want in self._described:
-            return self._described[want]
+            base = self._described[want]
+            return self._with_picklist_values(base) if with_values else base
         data = self.client.get(_META_FULL)
         members = (data or {}).get("hydra:member") or []
         hit = next(
@@ -101,8 +130,14 @@ class ModulesAPI(BaseAPI):
             fields.append(
                 {
                     "name": a.get("name"),
-                    "title": a.get("title") or a.get("displayName") or a.get("name"),
+                    "title": _friendly(
+                        a.get("title"),
+                        (a.get("descriptions") or {}).get("singular"),
+                        a.get("displayName"),
+                        a.get("name"),
+                    ),
                     "type": a.get("type") or a.get("formType"),
+                    "form_type": a.get("formType"),
                     "required": bool(
                         isinstance(validation, dict) and validation.get("required") is True
                     ),
@@ -111,10 +146,117 @@ class ModulesAPI(BaseAPI):
             )
         out = {
             "module": hit.get("type"),
-            "label": hit.get("displayName") or hit.get("module") or hit.get("type"),
+            "label": _friendly(
+                hit.get("displayName"),
+                (hit.get("descriptions") or {}).get("singular"),
+                hit.get("module"),
+                hit.get("type"),
+            ),
             "plural": hit.get("module"),
             "field_count": len(fields),
             "fields": fields,
         }
         self._described[want] = out
+        return self._with_picklist_values(out) if with_values else out
+
+    def _with_picklist_values(self, described: dict[str, Any]) -> dict[str, Any]:
+        """Return a copy of a describe() result with ``picklist_values`` added to
+        each picklist-backed field (friendly itemValues)."""
+        if "fields" not in described:
+            return described
+        enriched = []
+        for f in described["fields"]:
+            f = dict(f)
+            name = f.get("picklist_name")
+            if name:
+                try:
+                    f["picklist_values"] = self.client.picklists.options(name)
+                except Exception:
+                    f["picklist_values"] = []
+            enriched.append(f)
+        out = dict(described)
+        out["fields"] = enriched
         return out
+
+    # ------------------------------------------------------------- search
+    def search(self, query: str, *, refresh: bool = False) -> list[dict[str, Any]]:
+        """Return modules whose type, label, or plural contains ``query`` (case-insensitive).
+
+        >>> client.modules.search("incid")
+        [{'type': 'incidents', 'label': 'Incident', 'plural': 'incidents'}]
+        """
+        q = query.strip().lower()
+        return [
+            m
+            for m in self.list(refresh=refresh)
+            if q in str(m["type"]).lower()
+            or q in str(m["label"]).lower()
+            or q in str(m["plural"]).lower()
+        ]
+
+    def fields(self, module: str, *, refresh: bool = False) -> list[dict[str, Any]]:
+        """Shortcut for ``describe(module)['fields']`` (empty list if not found)."""
+        return self.describe(module, refresh=refresh).get("fields", [])
+
+    def find_field(
+        self,
+        name: str | None = None,
+        *,
+        type: str | None = None,
+        required: bool | None = None,
+        refresh: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Search fields across **all** modules.
+
+        Filters (all optional, AND-combined): ``name`` substring (case-insensitive),
+        exact field ``type``, and ``required``. Returns ``[{module, field}, ...]``.
+
+        >>> client.modules.find_field(type="json")          # every JSON field, any module
+        >>> client.modules.find_field(name="severity")      # where does 'severity' live
+        """
+        nq = name.strip().lower() if name else None
+        hits: list[dict[str, Any]] = []
+        for mod in self.list(refresh=refresh):
+            for f in self.fields(mod["type"]):
+                if nq and nq not in str(f["name"]).lower() and nq not in str(f["title"]).lower():
+                    continue
+                if type is not None and f.get("type") != type:
+                    continue
+                if required is not None and bool(f.get("required")) != required:
+                    continue
+                hits.append({"module": mod["type"], "field": f})
+        return hits
+
+    def format_module(self, module: str, *, refresh: bool = False,
+                      with_values: bool = True) -> str:
+        """Return a human-readable description of a module and its fields.
+
+        Handy for a quick "print one module as a sample" — e.g.
+        ``print(client.modules.format_module("alerts"))``. By default it also
+        lists the valid friendly values of each picklist field so an AI can see
+        what to use.
+        """
+        d = self.describe(module, refresh=refresh, with_values=with_values)
+        if "error" in d:
+            return f"{d['error']}\navailable: {', '.join(d.get('available', []))}"
+        lines = [
+            f"Module: {d['label']}  (type={d['module']}, plural={d['plural']})",
+            f"Fields: {d['field_count']}",
+            f"  {'NAME':<28} {'TYPE':<18} {'REQ':<4} {'TITLE'}",
+            f"  {'-' * 28} {'-' * 18} {'-' * 4} {'-' * 20}",
+        ]
+        for f in d["fields"]:
+            req = "yes" if f.get("required") else ""
+            pick = f"  [picklist: {f['picklist_name']}]" if f.get("picklist_name") else ""
+            lines.append(
+                f"  {str(f['name']):<28} {str(f.get('type')):<18} {req:<4} {f.get('title', '')}{pick}"
+            )
+            vals = f.get("picklist_values")
+            if vals:
+                shown = ", ".join(vals[:25]) + ("  …" if len(vals) > 25 else "")
+                lines.append(f"  {'':<28} {'':<18} {'':<4} valid: {shown}")
+        return "\n".join(lines)
+
+    def print_module(self, module: str, *, refresh: bool = False) -> None:
+        """Print :meth:`format_module` to stdout."""
+        print(self.format_module(module, refresh=refresh))

--- a/src/pyfsr/api/modules_admin.py
+++ b/src/pyfsr/api/modules_admin.py
@@ -1,0 +1,343 @@
+"""Module schema administration: create modules, add/alter fields, publish.
+
+Where :class:`~pyfsr.api.modules.ModulesAPI` is read-only *discovery*, this is the
+*write* surface for the Application/Module Editor. It drives the same endpoints the
+in-product editor and the "Clone Module" playbook use:
+
+- **Staging** lives at ``/api/3/staging_model_metadatas`` — the editable draft. Creating
+  a module or changing a field edits staging only; nothing is live yet.
+- **Published** lives at ``/api/3/model_metadatas`` — the committed schema records read.
+- **Publish** is a single global ``PUT /api/publish`` that promotes *all* pending staged
+  changes on the appliance to live. It is **appliance-wide**, not per-module — see
+  :meth:`publish`.
+
+A module is a staging record with an ``attributes`` list; each attribute (field) carries a
+``type`` (the storage type, e.g. ``text`` / ``json`` / ``integer``) and a ``formType`` (the
+UI widget, e.g. ``text`` / ``textarea`` / ``json`` / ``datetime``).
+
+Example::
+
+    admin = client.modules_admin
+    admin.create_module("widgets", label="Widget", fields=[
+        admin.field("name", db_type="text", form_type="text", required=True),
+        admin.field("payload", db_type="text", form_type="textarea"),
+    ])
+    admin.set_field_type("widgets", "payload", db_type="json", form_type="json")
+    admin.publish()                      # appliance-wide commit
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from ..exceptions import FortiSOARException
+from .base import BaseAPI
+
+_STAGING = "/api/3/staging_model_metadatas"
+_PUBLISHED = "/api/3/model_metadatas"
+_PUBLISH = "/api/publish"
+_REL = {"$relationships": "true"}
+_ALL = {"$limit": 2147483647}
+
+# Substrings the appliance returns (as 5xx bodies / error messages) while a publish
+# is mid-flight — it runs a full backup + DB migrate cycle and the API is briefly
+# unavailable, surfacing transient state strings instead of real errors.
+_PUBLISH_TRANSIENT_MARKERS = (
+    "decrypt database",
+    "encrypt database",
+    "cleaning up old backups",
+    "creating backup",
+    "taking backup",
+    "restoring",
+    "migrat",  # "migrating" / "migration in progress"
+    "backup",
+    "service temporarily unavailable",
+    "service unavailable",
+    "bad gateway",
+    "gateway time-out",
+    "gateway timeout",
+)
+
+
+class ModulesAdminAPI(BaseAPI):
+    """Create modules, add/alter fields, and publish schema changes."""
+
+    # --------------------------------------------------------------- read
+    def _staging_lite(self, module: str) -> dict[str, Any] | None:
+        """Return the lightweight staging row for ``module`` (by type), or None."""
+        want = module.strip().lower()
+        data = self.client.get(_STAGING, params=_ALL)
+        for m in (data or {}).get("hydra:member", []):
+            if str(m.get("type", "")).lower() == want or str(m.get("module", "")).lower() == want:
+                return m
+        return None
+
+    def get_staging(self, module: str) -> dict[str, Any] | None:
+        """Return the full staging metadata record (incl. ``attributes``) for ``module``.
+
+        ``module`` is the module ``type`` (or plural ``module`` name). Returns None if no
+        staging record exists.
+        """
+        lite = self._staging_lite(module)
+        if not lite:
+            return None
+        return self.client.get(f"{_STAGING}/{lite['uuid']}", params=_REL)
+
+    def get_published(self, module: str) -> dict[str, Any] | None:
+        """Return the full *published* metadata record for ``module``, or None.
+
+        None means the module has never been published (it may still exist in staging).
+        """
+        want = module.strip().lower()
+        data = self.client.get(_PUBLISHED, params=_ALL)
+        lite = next(
+            (
+                m
+                for m in (data or {}).get("hydra:member", [])
+                if str(m.get("type", "")).lower() == want
+                or str(m.get("module", "")).lower() == want
+            ),
+            None,
+        )
+        if not lite:
+            return None
+        return self.client.get(f"{_PUBLISHED}/{lite['uuid']}", params=_REL)
+
+    def is_published(self, module: str) -> bool:
+        """True if ``module`` exists in the published schema (``model_metadatas``)."""
+        return self.get_published(module) is not None
+
+    def get_field(self, module: str, field: str) -> dict[str, Any] | None:
+        """Return one staged attribute (field) dict by ``name``, or None."""
+        mod = self.get_staging(module)
+        if not mod:
+            return None
+        return next((a for a in mod.get("attributes", []) if a.get("name") == field), None)
+
+    # ------------------------------------------------------------- helpers
+    @staticmethod
+    def field(
+        name: str,
+        *,
+        db_type: str = "text",
+        form_type: str | None = None,
+        label: str | None = None,
+        required: bool = False,
+        searchable: bool = False,
+        maxlength: int = 10485760,
+        **extra: Any,
+    ) -> dict[str, Any]:
+        """Build an attribute (field) dict with sane defaults for create/add.
+
+        ``db_type`` is the storage type (``text``/``json``/``integer``/...); ``form_type``
+        is the UI widget (defaults to ``db_type``). Extra keys override the defaults.
+        """
+        attr = {
+            "name": name,
+            "type": db_type,
+            "formType": form_type or db_type,
+            "descriptions": {"singular": label or name},
+            "displayName": f"{{{{ {name} }}}}",
+            "searchable": searchable,
+            "collection": False,
+            "visibility": True,
+            "readable": True,
+            "writeable": True,
+            "validation": {"required": required, "minlength": 0, "maxlength": maxlength},
+        }
+        attr.update(extra)
+        return attr
+
+    # -------------------------------------------------------------- write
+    def create_module(
+        self,
+        module: str,
+        *,
+        label: str | None = None,
+        plural: str | None = None,
+        fields: list[dict[str, Any]] | None = None,
+        display_template: str | None = None,
+        ownable: bool = True,
+        taggable: bool = False,
+        **opts: Any,
+    ) -> dict[str, Any]:
+        """Create a new module in **staging** (not yet live — call :meth:`publish`).
+
+        ``module`` is the type/table name. ``fields`` is a list of attribute dicts (use
+        :meth:`field`); if omitted, a single required ``name`` text field is created so the
+        module is valid. Returns the created staging record.
+
+        ``display_template`` is the module's **Display Template** — the Jinja expression
+        used to render a record's title throughout the UI. It must reference a field, e.g.
+        ``"{{ name }}"`` (this is the top-level ``displayName`` on the metadata record, NOT
+        the human label, which lives in ``descriptions``). If omitted it defaults to the
+        first field, preferring a field literally named ``name``.
+        """
+        label = label or module
+        if fields is None:
+            fields = [self.field("name", db_type="text", form_type="text", required=True)]
+        if display_template is None:
+            names = [f.get("name") for f in fields if f.get("name")]
+            anchor = "name" if "name" in names else (names[0] if names else "name")
+            display_template = f"{{{{ {anchor} }}}}"
+        payload = {
+            "type": module,
+            "module": module,
+            "tableName": module,
+            "displayName": display_template,
+            "descriptions": {"singular": label, "plural": plural or f"{label}s"},
+            "ownable": ownable,
+            "userOwnable": ownable,
+            "taggable": taggable,
+            "trackable": True,
+            "indexable": True,
+            "writable": True,
+            "queueable": False,
+            "system": False,
+            "attributes": fields,
+        }
+        payload.update(opts)
+        return self.client.post(_STAGING, data=payload, params=_REL)
+
+    def _put_attributes(self, mod: dict[str, Any], attributes: list[dict[str, Any]]) -> dict[str, Any]:
+        """PUT only the ``attributes`` of a staging record (a full-record PUT is
+        rejected — the GET payload carries read-only ``@id``/``@context`` keys)."""
+        return self.client.put(
+            f"{_STAGING}/{mod['uuid']}", data={"attributes": attributes}, params=_REL
+        )
+
+    def add_field(self, module: str, field: dict[str, Any]) -> dict[str, Any]:
+        """Append a field (build it with :meth:`field`) to ``module`` in staging."""
+        mod = self.get_staging(module)
+        if not mod:
+            raise ValueError(f"module {module!r} not found in staging")
+        attrs = mod.get("attributes", []) + [field]
+        return self._put_attributes(mod, attrs)
+
+    def set_field_type(
+        self, module: str, field: str, *, db_type: str, form_type: str | None = None
+    ) -> dict[str, Any]:
+        """Change a staged field's storage ``type`` (and ``formType``).
+
+        Edits go through a PUT of the whole staging record — individual
+        ``attribute_metadatas`` are read-only on the platform. Change is staged until
+        :meth:`publish`.
+        """
+        mod = self.get_staging(module)
+        if not mod:
+            raise ValueError(f"module {module!r} not found in staging")
+        attr = next((a for a in mod.get("attributes", []) if a.get("name") == field), None)
+        if attr is None:
+            raise ValueError(f"field {field!r} not found on module {module!r}")
+        attr["type"] = db_type
+        attr["formType"] = form_type or db_type
+        return self._put_attributes(mod, mod["attributes"])
+
+    def discard_staging_draft(self, module: str) -> bool:
+        """Discard a module's editable **staging draft** (``DELETE`` on staging). Returns
+        False if no draft existed.
+
+        ⚠️ **This is NOT a module delete.** FortiSOAR has no supported delete-module
+        operation (the in-product editor cannot delete modules either). This only drops the
+        *unpublished* staging draft:
+
+        - If the module was **never published**, that effectively removes it (no table was
+          ever created).
+        - If the module **was published**, the live module and its Postgres table REMAIN —
+          you just orphan them by removing the draft, with **no API path to fully delete**
+          them (requires backend CLI/SQL). Prefer leaving the draft in place.
+
+        For a clean throwaway, do NOT publish it; then discarding the draft removes it.
+        """
+        lite = self._staging_lite(module)
+        if not lite:
+            return False
+        self.client.delete(f"{_STAGING}/{lite['uuid']}")
+        return True
+
+    @staticmethod
+    def _is_publish_transient(exc: Exception) -> bool:
+        """True if ``exc`` is a transient state surfaced while a publish is in flight.
+
+        During a publish the appliance runs a backup + DB migrate cycle and the API is
+        briefly down, returning 5xx and/or state strings like "Decrypt Database" /
+        "Cleaning Up Old Backups" rather than a real error. We treat any 5xx, plus any
+        error message matching a known migrate-cycle marker, as "still working".
+        """
+        status = getattr(exc, "status_code", None)
+        if isinstance(status, int) and status >= 500:
+            return True
+        text = " ".join(
+            str(getattr(exc, attr, "") or "")
+            for attr in ("message", "error_type")
+        ).lower() or str(exc).lower()
+        return any(marker in text for marker in _PUBLISH_TRANSIENT_MARKERS)
+
+    def _wait_until_ready(self, timeout: float, poll_interval: float) -> None:
+        """Poll a cheap read until the appliance finishes the publish/migrate cycle.
+
+        Raises :class:`TimeoutError` if it does not recover within ``timeout`` seconds, or
+        re-raises any non-transient error encountered while probing.
+        """
+        deadline = time.monotonic() + timeout
+        last_exc: Exception | None = None
+        while True:
+            try:
+                self.client.get(_PUBLISHED, params={"$limit": 1})
+                return
+            except FortiSOARException as exc:
+                if not self._is_publish_transient(exc):
+                    raise
+                last_exc = exc
+            except Exception as exc:  # network drop mid-restart counts as transient
+                last_exc = exc
+            if time.monotonic() >= deadline:
+                raise TimeoutError(
+                    f"publish did not complete within {timeout}s "
+                    f"(last appliance state: {last_exc})"
+                )
+            time.sleep(poll_interval)
+
+    def publish(
+        self,
+        *,
+        wait: bool = True,
+        timeout: float = 600.0,
+        poll_interval: float = 10.0,
+    ) -> dict[str, Any] | None:
+        """Commit **all** pending staged schema changes to live (``PUT /api/publish``).
+
+        ⚠️ Appliance-wide: this publishes every pending change in staging across the whole
+        instance, not just modules you touched. On a shared appliance, confirm nothing else
+        is mid-edit before calling.
+
+        The publish triggers a full backup + DB migrate cycle during which the API is
+        briefly unavailable, returning 5xx and transient state strings ("Decrypt Database",
+        "Cleaning Up Old Backups", ...). By default this method is **synchronous**: it
+        tolerates those transient states on the initial call and then polls until the
+        appliance has finished, so callers can safely read back the published schema
+        immediately on return.
+
+        Args:
+            wait: If True (default), block until the publish/migrate cycle completes. If
+                False, fire-and-forget — return as soon as the PUT is accepted (legacy
+                behavior; the caller must handle transient states themselves).
+            timeout: Max seconds to wait for completion when ``wait`` is True.
+            poll_interval: Seconds between readiness probes.
+
+        Returns:
+            The publish response when available; ``None`` if the PUT response was consumed
+            by the transient migrate cycle but the publish otherwise completed.
+        """
+        result: dict[str, Any] | None = None
+        try:
+            result = self.client.put(_PUBLISH, data={})
+        except FortiSOARException as exc:
+            # The PUT itself can return a transient migrate-state body; that means the
+            # publish was accepted and is running, not that it failed.
+            if not (wait and self._is_publish_transient(exc)):
+                raise
+        if wait:
+            self._wait_until_ready(timeout, poll_interval)
+        return result

--- a/src/pyfsr/api/modules_admin.py
+++ b/src/pyfsr/api/modules_admin.py
@@ -200,7 +200,9 @@ class ModulesAdminAPI(BaseAPI):
         payload.update(opts)
         return self.client.post(_STAGING, data=payload, params=_REL)
 
-    def _put_attributes(self, mod: dict[str, Any], attributes: list[dict[str, Any]]) -> dict[str, Any]:
+    def _put_attributes(
+        self, mod: dict[str, Any], attributes: list[dict[str, Any]]
+    ) -> dict[str, Any]:
         """PUT only the ``attributes`` of a staging record (a full-record PUT is
         rejected — the GET payload carries read-only ``@id``/``@context`` keys)."""
         return self.client.put(

--- a/src/pyfsr/api/modules_admin.py
+++ b/src/pyfsr/api/modules_admin.py
@@ -9,7 +9,7 @@ in-product editor and the "Clone Module" playbook use:
 - **Published** lives at ``/api/3/model_metadatas`` — the committed schema records read.
 - **Publish** is a single global ``PUT /api/publish`` that promotes *all* pending staged
   changes on the appliance to live. It is **appliance-wide**, not per-module — see
-  :meth:`publish`.
+  :meth:`ModulesAdminAPI.publish`.
 
 A module is a staging record with an ``attributes`` list; each attribute (field) carries a
 ``type`` (the storage type, e.g. ``text`` / ``json`` / ``integer``) and a ``formType`` (the
@@ -270,10 +270,12 @@ class ModulesAdminAPI(BaseAPI):
         status = getattr(exc, "status_code", None)
         if isinstance(status, int) and status >= 500:
             return True
-        text = " ".join(
-            str(getattr(exc, attr, "") or "")
-            for attr in ("message", "error_type")
-        ).lower() or str(exc).lower()
+        text = (
+            " ".join(
+                str(getattr(exc, attr, "") or "") for attr in ("message", "error_type")
+            ).lower()
+            or str(exc).lower()
+        )
         return any(marker in text for marker in _PUBLISH_TRANSIENT_MARKERS)
 
     def _wait_until_ready(self, timeout: float, poll_interval: float) -> None:
@@ -296,8 +298,7 @@ class ModulesAdminAPI(BaseAPI):
                 last_exc = exc
             if time.monotonic() >= deadline:
                 raise TimeoutError(
-                    f"publish did not complete within {timeout}s "
-                    f"(last appliance state: {last_exc})"
+                    f"publish did not complete within {timeout}s (last appliance state: {last_exc})"
                 )
             time.sleep(poll_interval)
 

--- a/src/pyfsr/api/picklists.py
+++ b/src/pyfsr/api/picklists.py
@@ -201,8 +201,9 @@ class PicklistsAPI(BaseAPI):
                     continue
                 valid = self.options(picklist)
                 if report is not None:
-                    report.append({"field": k, "value": v, "picklist": picklist,
-                                   "valid_values": valid})
+                    report.append(
+                        {"field": k, "value": v, "picklist": picklist, "valid_values": valid}
+                    )
                 if strict:
                     raise PicklistResolutionError(k, v, picklist, valid)
             out[k] = v

--- a/src/pyfsr/api/picklists.py
+++ b/src/pyfsr/api/picklists.py
@@ -163,13 +163,33 @@ class PicklistsAPI(BaseAPI):
                 return iri
         return None
 
-    def resolve_record_fields(self, module: str, fields: dict[str, Any]) -> dict[str, Any]:
+    def options(self, picklist_name: str) -> list[str]:
+        """The valid friendly values (itemValues) of a picklist — what an AI
+        should choose from. Cached via :meth:`values`."""
+        return [it.get("itemValue") for it in self.values(picklist_name) if it.get("itemValue")]
+
+    def resolve_record_fields(
+        self,
+        module: str,
+        fields: dict[str, Any],
+        *,
+        strict: bool = False,
+        report: list | None = None,
+    ) -> dict[str, Any]:
         """Return a copy of ``fields`` with picklist-typed values mapped to IRIs.
 
         Only fields the module flags as picklist-backed are touched, and only
-        when their value is a friendly string (not already an IRI). Unresolvable
-        values are left as-is so the caller still sees the original input.
+        when their value is a friendly string (not already an IRI).
+
+        Friendly feedback on a miss (a value not in the picklist):
+          - ``strict=True`` raises :class:`~pyfsr.exceptions.PicklistResolutionError`
+            naming the field, bad value, and the valid options.
+          - pass a list as ``report`` to collect misses as
+            ``{field, value, picklist, valid_values}`` without raising.
+          - by default the original value is left in place (back-compatible).
         """
+        from ..exceptions import PicklistResolutionError
+
         fmap = self._field_map(module)
         out: dict[str, Any] = {}
         for k, v in fields.items():
@@ -179,5 +199,11 @@ class PicklistsAPI(BaseAPI):
                 if iri:
                     out[k] = iri
                     continue
+                valid = self.options(picklist)
+                if report is not None:
+                    report.append({"field": k, "value": v, "picklist": picklist,
+                                   "valid_values": valid})
+                if strict:
+                    raise PicklistResolutionError(k, v, picklist, valid)
             out[k] = v
         return out

--- a/src/pyfsr/api/playbooks.py
+++ b/src/pyfsr/api/playbooks.py
@@ -111,20 +111,33 @@ class PlaybooksAPI(BaseAPI):
             return [WorkflowRun(**m) for m in members]
         return members if raw else [_shape_run(m) for m in members]
 
-    def get(self, run_pk: str, *, raw: bool = False, typed: bool = False) -> dict[str, Any]:
+    def get(
+        self,
+        run_pk: str,
+        *,
+        raw: bool = False,
+        typed: bool = False,
+        step_detail: bool = False,
+    ) -> dict[str, Any]:
         """Fetch one run by its pk (the trailing id of a run's ``@id``).
 
         Tries the live table first, then historical. Returns a shaped dict by
         default; ``raw=True`` for the full record, or ``typed=True`` for a
         ``WorkflowRun``. ``typed`` wins over ``raw``.
+
+        Pass ``step_detail=True`` to ask FortiSOAR for the per-step execution
+        trace (``?step_detail=true``); the step results land under the run
+        record's ``workflow``/``result`` structure. ``step_detail`` implies
+        ``raw`` (the shaped view drops the trace), unless ``typed`` is set.
         """
         if not isinstance(run_pk, str) or not run_pk.strip():
             raise ValueError("get() requires a non-empty run pk")
         run_pk = run_pk.strip()
+        suffix = "&step_detail=true" if step_detail else ""
         last_err: Exception | None = None
         for path in _RUN_PATHS:
             try:
-                resp = self.client.get(f"{path}{run_pk}/?format=json")
+                resp = self.client.get(f"{path}{run_pk}/?format=json{suffix}")
             except Exception as e:  # noqa: BLE001 - fall through to historical
                 last_err = e
                 continue
@@ -135,10 +148,49 @@ class PlaybooksAPI(BaseAPI):
                     from ..models import WorkflowRun
 
                     return WorkflowRun(**resp)
+                if step_detail:
+                    return resp
                 return resp if raw else _shape_run(resp)
         if last_err is not None:
             raise last_err
         raise ValueError(f"run {run_pk!r} not found")
+
+    def run_env(self, run_pk: str) -> dict[str, Any]:
+        """Return a run's execution environment + per-step results.
+
+        Fetches the run with ``step_detail=true`` and reshapes it into the
+        Jinja-context view used when authoring/debugging a playbook::
+
+            {
+              "env":   {...},                      # the run's top-level env dict
+                                                   # (input, request, resources, …)
+              "status": "finished",
+              "steps": {                           # keyed by step display name
+                "Step Name": {"status": ..., "result": {...}},
+                ...
+              },
+            }
+
+        Step names are returned verbatim; in Jinja they are referenced as
+        ``vars.steps.<name with spaces replaced by underscores>``.
+        """
+        full = self.get(run_pk, step_detail=True)
+        steps: dict[str, Any] = {}
+        for s in full.get("steps") or []:
+            if not isinstance(s, dict):
+                continue
+            name = s.get("name")
+            if not name:
+                md = s.get("metadata") or {}
+                name = (md.get("metadata") or {}).get("name") or md.get("name")
+            if not name:
+                continue
+            steps[name] = {"status": s.get("status"), "result": s.get("result")}
+        return {
+            "env": full.get("env") or {},
+            "status": full.get("status"),
+            "steps": steps,
+        }
 
     # ---------------------------------------------------------------- resume
     def resume(

--- a/src/pyfsr/api/wf_tools.py
+++ b/src/pyfsr/api/wf_tools.py
@@ -1,0 +1,69 @@
+"""Workflow-engine authoring helpers: Jinja rendering and global variables.
+
+Wraps the two ``/api/wf/api`` endpoints used when authoring/debugging a
+playbook outside the visual editor. Accessed as ``client.wf_tools``.
+
+Example:
+    >>> client.wf_tools.render("{{ vars.x + 2 }}", {"vars": {"x": 5}})
+    7
+    >>> client.wf_tools.dynamic_variable("Default_Indicator_TTL_Days")
+    '20'
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import BaseAPI
+
+
+class WfToolsAPI(BaseAPI):
+    """Jinja rendering + FortiSOAR global ("dynamic") variables."""
+
+    def __init__(self, client):
+        super().__init__(client)
+
+    # ------------------------------------------------------------- jinja
+    def render(self, template: str, values: dict[str, Any] | None = None) -> Any:
+        """Render a Jinja ``template`` server-side and return the result value.
+
+        Uses the workflow engine's own renderer
+        (``POST /api/wf/api/jinja-editor/``) so the output matches what a running
+        playbook would produce. ``values`` is the context dict (typically
+        ``{"vars": {...}}``); see :meth:`pyfsr.api.playbooks.PlaybooksAPI.run_env`
+        to build it from a real run.
+
+        Returns the unwrapped ``result`` (a scalar, list, or dict). Use
+        :meth:`render_raw` for the full response envelope.
+        """
+        resp = self.render_raw(template, values)
+        if isinstance(resp, dict) and "result" in resp:
+            return resp["result"]
+        return resp
+
+    def render_raw(self, template: str, values: dict[str, Any] | None = None) -> Any:
+        """Render a template and return the raw server response (``{"result": ...}``)."""
+        return self.client.post(
+            "/api/wf/api/jinja-editor/",
+            data={"template": template, "values": values or {}},
+        )
+
+    # ------------------------------------------------------- global variables
+    def dynamic_variables(self) -> list[dict[str, Any]]:
+        """List every FortiSOAR global ("dynamic") variable.
+
+        ``GET /api/wf/api/dynamic-variable/`` — returns
+        ``[{id, name, value, default_value}, ...]`` (referenced in playbooks as
+        ``{{ globalVars.<name> }}``).
+        """
+        resp = self.client.get(
+            "/api/wf/api/dynamic-variable/", params={"offset": 0, "limit": 2147483647}
+        )
+        return (resp or {}).get("hydra:member") or []
+
+    def dynamic_variable(self, name: str) -> str | None:
+        """Return the value of one global variable by ``name`` (``None`` if absent)."""
+        for v in self.dynamic_variables():
+            if v.get("name") == name:
+                return v.get("value")
+        return None

--- a/src/pyfsr/client.py
+++ b/src/pyfsr/client.py
@@ -18,6 +18,7 @@ from .api.modules import ModulesAPI
 from .api.picklists import PicklistsAPI
 from .api.playbooks import PlaybooksAPI
 from .api.solution_packs import SolutionPackAPI
+from .api.wf_tools import WfToolsAPI
 from .auth.api_key import APIKeyAuth
 from .auth.base import BaseAuth
 from .auth.user_pass import UserPasswordAuth
@@ -195,6 +196,9 @@ class FortiSOAR:
 
         # Playbook run history + manual-input resume
         self.playbooks: PlaybooksAPI = PlaybooksAPI(self)
+
+        # Workflow-engine authoring helpers (Jinja render, global variables)
+        self.wf_tools: WfToolsAPI = WfToolsAPI(self)
 
         self.solution_packs: SolutionPackAPI = SolutionPackAPI(self, self.export_config)
 

--- a/src/pyfsr/client.py
+++ b/src/pyfsr/client.py
@@ -15,6 +15,7 @@ from .api.connectors import ConnectorsAPI
 from .api.content_hub import ContentHubSearch
 from .api.export_config import ExportConfigAPI
 from .api.modules import ModulesAPI
+from .api.modules_admin import ModulesAdminAPI
 from .api.picklists import PicklistsAPI
 from .api.playbooks import PlaybooksAPI
 from .api.solution_packs import SolutionPackAPI
@@ -187,6 +188,9 @@ class FortiSOAR:
 
         # Module / field schema discovery
         self.modules: ModulesAPI = ModulesAPI(self)
+
+        # Module / field schema administration (create, alter fields, publish)
+        self.modules_admin: ModulesAdminAPI = ModulesAdminAPI(self)
 
         # Picklist discovery + friendly-value -> IRI resolution
         self.picklists: PicklistsAPI = PicklistsAPI(self)

--- a/src/pyfsr/exceptions.py
+++ b/src/pyfsr/exceptions.py
@@ -24,6 +24,25 @@ class ValidationError(FortiSOARException):
     pass
 
 
+class PicklistResolutionError(ValidationError):
+    """Raised when a friendly picklist value can't be mapped to an IRI.
+
+    Carries the offending field/value, the picklist name, and the valid options
+    so callers (and AIs) get an actionable message instead of a server 400.
+    """
+
+    def __init__(self, field: str, value, picklist: str, valid_values: list[str]):
+        self.field = field
+        self.value = value
+        self.picklist = picklist
+        self.valid_values = valid_values
+        shown = ", ".join(valid_values[:25]) + ("  …" if len(valid_values) > 25 else "")
+        super().__init__(
+            f"{field}={value!r} is not a valid '{picklist}' value. "
+            f"Valid ({len(valid_values)}): {shown}"
+        )
+
+
 class AuthenticationError(FortiSOARException):
     """Raised when authentication fails."""
 
@@ -58,6 +77,40 @@ class UnsupportedAuthOperationError(FortiSOARException):
         super().__init__(msg)
 
 
+def _extract_message(error_data):
+    """Pull a human-readable message out of a FortiSOAR/Symfony error body.
+
+    FortiSOAR returns at least two error shapes:
+
+    - ``{"message": "..."}`` — the simple form.
+    - Symfony validation errors — ``{"title": "Validation Failed", "detail": "...",
+      "violations": [{"propertyPath": "...", "title": "..."}]}`` with **no** ``message``
+      key. Reading only ``message`` collapsed these to "Unknown error occurred", hiding the
+      real cause (e.g. an invalid attribute ``type`` rejected at ``/api/publish``).
+
+    Prefer ``detail`` (most specific), then a rollup of ``violations``, then ``title``,
+    then ``message``. Returns None if nothing usable is present.
+    """
+    if not isinstance(error_data, dict):
+        return str(error_data) or None
+    if error_data.get("message"):
+        return error_data["message"]
+    if error_data.get("detail"):
+        return error_data["detail"]
+    violations = error_data.get("violations")
+    if isinstance(violations, list) and violations:
+        parts = []
+        for v in violations:
+            if not isinstance(v, dict):
+                continue
+            path, title = v.get("propertyPath"), v.get("title") or v.get("message")
+            parts.append(f"{path}: {title}" if path and title else (title or path or ""))
+        rolled = "; ".join(p for p in parts if p)
+        if rolled:
+            return rolled
+    return error_data.get("title")
+
+
 def handle_api_error(response):
     """Convert API error responses to appropriate exceptions."""
     try:
@@ -66,7 +119,7 @@ def handle_api_error(response):
         error_data = {"message": response.text}
 
     error_type = error_data.get("type", "")
-    message = error_data.get("message", "Unknown error occurred")
+    message = _extract_message(error_data) or "Unknown error occurred"
 
     if response.status_code == 400:
         if "ValidationException" in error_type:

--- a/src/pyfsr/query.py
+++ b/src/pyfsr/query.py
@@ -40,6 +40,10 @@ OPERATORS = frozenset(
         "contains",
         "exists",
         "isnull",
+        # Trigger-condition operators (used by playbook start filters / visual
+        # editor wire shapes). ``changed`` is value-less; ``in_all`` takes a list.
+        "changed",
+        "in_all",
     }
 )
 
@@ -115,6 +119,20 @@ class Query:
 
     def isnull(self, field: str, value: bool = True) -> Query:
         return self.where(field, "isnull", value)
+
+    def changed(self, field: str) -> Query:
+        """Match records whose ``field`` changed (trigger-condition operator).
+
+        Value-less — only meaningful inside a playbook start/update trigger filter.
+        """
+        return self.where(field, "changed")
+
+    def in_all(self, field: str, values: list[Any]) -> Query:
+        """Match records whose ``field`` contains *all* of ``values``.
+
+        Trigger-condition operator (distinct from ``in``, which is any-of).
+        """
+        return self.where(field, "in_all", list(values))
 
     def group(self, query: Query) -> Query:
         """Nest another ``Query`` as a sub-group (its own logic + filters)."""

--- a/src/pyfsr/records.py
+++ b/src/pyfsr/records.py
@@ -289,6 +289,50 @@ class RecordSet:
         path = resolve_record_path(self.module, ref)
         return self._parse(self.client.put(path, data=data), raw=raw)
 
+    def upsert(
+        self,
+        data: dict[str, Any],
+        *,
+        raw: bool = False,
+        resolve_picklists: bool = False,
+    ) -> Any:
+        """Insert-or-update one record via ``POST /api/3/upsert/<module>``.
+
+        FortiSOAR matches an existing row by the record's natural key (its
+        ``uuid`` / ``@id`` when present, else the module's unique field) and
+        updates it, otherwise creates a new one. ``data`` may be a dict or a
+        model instance; pass ``resolve_picklists=True`` to map friendly picklist
+        values to IRIs first (see :meth:`create`).
+        """
+        if isinstance(data, BaseRecord):
+            data = data.to_dict(exclude_none=True)
+        if resolve_picklists:
+            data = self.client.picklists.resolve_record_fields(self.module, data)
+        return self._parse(self.client.post(f"/api/3/upsert/{self.module}", data=data), raw=raw)
+
+    def bulk_upsert(
+        self,
+        rows: list[dict[str, Any]],
+        *,
+        resolve_picklists: bool = False,
+    ) -> dict[str, Any]:
+        """Insert-or-update many records via ``POST /api/3/bulkupsert/<module>``.
+
+        ``rows`` is a list of dicts or model instances. Each row is matched the
+        same way as :meth:`upsert`. The raw server response is returned
+        unparsed — bulk endpoints reply with a multi-status (``207``) envelope
+        whose per-row results the caller usually wants to inspect directly.
+        Pass ``resolve_picklists=True`` to resolve picklist values on every row.
+        """
+        payload: list[dict[str, Any]] = []
+        for row in rows:
+            if isinstance(row, BaseRecord):
+                row = row.to_dict(exclude_none=True)
+            if resolve_picklists:
+                row = self.client.picklists.resolve_record_fields(self.module, row)
+            payload.append(row)
+        return self.client.post(f"/api/3/bulkupsert/{self.module}", data=payload)
+
     def _single_record_path(self, ref: str, *, action: str) -> str:
         """Resolve ``ref`` to a single-record path, refusing collection-wide refs.
 

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -160,3 +160,50 @@ def test_execute_config_name_selects_named():
     api.execute("virustotal", "op", config_name="Alt")
     _, body = _client.post_calls[0]
     assert body["config"] == "vt-alt"
+
+
+# -- definition / operations / files ---------------------------------------
+_DEFINITION = {
+    "name": "virustotal",
+    "version": "3.1.0",
+    "config_schema": {},
+    "operations": [
+        {"operation": "get_reputation_ip", "title": "IP Reputation", "parameters": []},
+        {"operation": "get_reputation_url", "title": "URL Reputation", "parameters": []},
+    ],
+}
+
+
+def test_definition_posts_with_format_json_and_resolves_version():
+    api, client = _api(post_resp=_DEFINITION)
+    defn = api.definition("virustotal")
+    assert defn["operations"][0]["operation"] == "get_reputation_ip"
+    endpoint, body = client.post_calls[0]
+    assert endpoint == "/api/integration/connectors/virustotal/3.1.0/?format=json"
+    assert body == {}
+
+
+def test_definition_explicit_version_overrides():
+    api, client = _api(post_resp=_DEFINITION)
+    api.definition("virustotal", version="9.9.9")
+    assert client.post_calls[0][0] == "/api/integration/connectors/virustotal/9.9.9/?format=json"
+
+
+def test_definition_unconfigured_raises():
+    import pytest
+
+    api, _ = _api()
+    with pytest.raises(ValueError, match="not configured"):
+        api.definition("nope")
+
+
+def test_operations_returns_operation_list():
+    api, _ = _api(post_resp=_DEFINITION)
+    ops = api.operations("virustotal")
+    assert [o["operation"] for o in ops] == ["get_reputation_ip", "get_reputation_url"]
+
+
+def test_files_hits_files_endpoint():
+    api, client = _api(get_map={"/api/integration/connector/dev-7/files/": {"files": []}})
+    assert api.files("dev-7") == {"files": []}
+    assert client.get_calls[-1][0] == "/api/integration/connector/dev-7/files/"

--- a/tests/unit/test_modules.py
+++ b/tests/unit/test_modules.py
@@ -73,3 +73,56 @@ def test_clear_cache_refetches():
     api.clear_cache()
     api.list()
     assert len(client.calls) == 2
+
+
+def test_search_modules_by_substring():
+    api = ModulesAPI(FakeClient())
+    assert [m["type"] for m in api.search("incid")] == ["incidents"]
+    assert api.search("zzz") == []
+
+
+def test_fields_shortcut():
+    api = ModulesAPI(FakeClient())
+    names = {f["name"] for f in api.fields("incidents")}
+    assert names == {"name", "severity"}
+
+
+def test_find_field_by_name_across_modules():
+    api = ModulesAPI(FakeClient())
+    hits = api.find_field(name="sever")
+    assert [(h["module"], h["field"]["name"]) for h in hits] == [("incidents", "severity")]
+
+
+def test_find_field_by_type():
+    api = ModulesAPI(FakeClient())
+    hits = api.find_field(type="picklist")
+    assert all(h["field"]["type"] == "picklist" for h in hits)
+    assert ("incidents", "severity") in [(h["module"], h["field"]["name"]) for h in hits]
+
+
+def test_format_module_is_readable():
+    out = ModulesAPI(FakeClient()).format_module("incidents")
+    assert "Module: Incidents" in out
+    assert "severity" in out and "picklist" in out
+
+
+_TEMPLATED = {
+    "hydra:member": [
+        {
+            "type": "widgets",
+            "module": "widgets",
+            "displayName": "{{ name }}",
+            "descriptions": {"singular": "Widget"},
+            "attributes": [],
+        }
+    ]
+}
+
+
+def test_friendly_label_skips_jinja_template():
+    class C:
+        def get(self, endpoint, params=None, **kwargs):
+            return _TEMPLATED
+
+    mods = ModulesAPI(C()).list()
+    assert mods[0]["label"] == "Widget"  # not the "{{ name }}" template

--- a/tests/unit/test_modules_admin.py
+++ b/tests/unit/test_modules_admin.py
@@ -1,0 +1,81 @@
+"""Unit tests for module/schema administration (create, alter, publish)."""
+
+from pyfsr.api.modules_admin import ModulesAdminAPI
+
+
+class RecordingClient:
+    """Records calls and returns canned staging data."""
+
+    def __init__(self):
+        self.calls = []
+        self.staging_full = {
+            "uuid": "u-1",
+            "type": "widgets",
+            "attributes": [
+                {"name": "name", "type": "string", "formType": "text"},
+                {"name": "payload", "type": "string", "formType": "textarea"},
+            ],
+        }
+
+    def get(self, endpoint, params=None, **kw):
+        self.calls.append(("GET", endpoint, params))
+        if endpoint.endswith("/u-1"):
+            return self.staging_full
+        return {"hydra:member": [{"type": "widgets", "module": "widgets", "uuid": "u-1"}]}
+
+    def post(self, endpoint, data=None, params=None, **kw):
+        self.calls.append(("POST", endpoint, data))
+        return {"uuid": "u-1", **(data or {})}
+
+    def put(self, endpoint, data=None, params=None, **kw):
+        self.calls.append(("PUT", endpoint, data))
+        return {"ok": True, **(data or {})}
+
+    def delete(self, endpoint, params=None, **kw):
+        self.calls.append(("DELETE", endpoint, params))
+
+
+def test_field_builder_defaults_and_overrides():
+    f = ModulesAdminAPI.field("payload", db_type="object", form_type="object", required=True)
+    assert f["name"] == "payload"
+    assert f["type"] == "object" and f["formType"] == "object"
+    assert f["validation"]["required"] is True
+    # form_type defaults to db_type
+    assert ModulesAdminAPI.field("x", db_type="string")["formType"] == "string"
+
+
+def test_create_module_payload_shape():
+    c = RecordingClient()
+    ModulesAdminAPI(c).create_module("widgets", label="Widget")
+    method, endpoint, data = c.calls[-1]
+    assert method == "POST" and endpoint == "/api/3/staging_model_metadatas"
+    assert data["type"] == "widgets" and data["tableName"] == "widgets"
+    # default single 'name' field added when none supplied
+    assert [a["name"] for a in data["attributes"]] == ["name"]
+
+
+def test_set_field_type_puts_only_attributes():
+    c = RecordingClient()
+    ModulesAdminAPI(c).set_field_type("widgets", "payload", db_type="object", form_type="object")
+    method, endpoint, data = c.calls[-1]
+    assert method == "PUT" and endpoint == "/api/3/staging_model_metadatas/u-1"
+    # body carries ONLY attributes (full-record PUT is rejected by the platform)
+    assert set(data.keys()) == {"attributes"}
+    changed = next(a for a in data["attributes"] if a["name"] == "payload")
+    assert changed["type"] == "object" and changed["formType"] == "object"
+
+
+def test_publish_hits_global_endpoint():
+    c = RecordingClient()
+    # wait=False → fire-and-forget, no readiness polling after the PUT.
+    ModulesAdminAPI(c).publish(wait=False)
+    assert c.calls[-1] == ("PUT", "/api/publish", {})
+
+
+def test_set_field_type_unknown_field_raises():
+    c = RecordingClient()
+    try:
+        ModulesAdminAPI(c).set_field_type("widgets", "nope", db_type="object")
+        assert False, "expected ValueError"
+    except ValueError as e:
+        assert "nope" in str(e)

--- a/tests/unit/test_playbooks.py
+++ b/tests/unit/test_playbooks.py
@@ -157,3 +157,34 @@ def test_resume_omits_approved_when_none():
 def test_resume_blank_pk_raises():
     with pytest.raises(ValueError):
         PlaybooksAPI(FakeClient()).resume("", manual_input_id=1)
+
+
+# -- get(step_detail=) / run_env -------------------------------------------
+def _run_with_steps(pk):
+    return {
+        "@id": f"/api/wf/api/workflows/{pk}/",
+        "name": "PB",
+        "status": "finished",
+        "env": {"input": {}, "wf_id": pk},
+        "steps": [
+            {"name": "Start", "status": "finished", "result": {"data": 1}},
+            {"name": "Fetch Email", "status": "finished", "result": {"data": 2}},
+        ],
+    }
+
+
+def test_get_step_detail_passes_flag_and_returns_full():
+    client = FakeClient(workflows=[_run_with_steps("900")])
+    api = PlaybooksAPI(client)
+    full = api.get("900", step_detail=True)
+    assert client.get_calls[0][0] == "/api/wf/api/workflows/900/?format=json&step_detail=true"
+    assert "steps" in full and len(full["steps"]) == 2
+
+
+def test_run_env_reshapes_env_and_steps():
+    client = FakeClient(workflows=[_run_with_steps("901")])
+    api = PlaybooksAPI(client)
+    env = api.run_env("901")
+    assert env["status"] == "finished"
+    assert env["env"]["wf_id"] == "901"
+    assert env["steps"]["Fetch Email"] == {"status": "finished", "result": {"data": 2}}

--- a/tests/unit/test_query.py
+++ b/tests/unit/test_query.py
@@ -80,3 +80,13 @@ def test_invalid_logic_and_direction():
         Query("XOR")
     with pytest.raises(ValueError, match="direction must be"):
         Query().sort("f", "sideways")
+
+
+def test_changed_operator_is_valueless():
+    body = Query().changed("status").to_body()
+    assert body["filters"] == [{"field": "status", "operator": "changed"}]
+
+
+def test_in_all_operator_takes_list():
+    body = Query().in_all("tags", ["a", "b"]).to_body()
+    assert body["filters"] == [{"field": "tags", "operator": "in_all", "value": ["a", "b"]}]

--- a/tests/unit/test_records.py
+++ b/tests/unit/test_records.py
@@ -222,3 +222,26 @@ def test_records_accessor_on_client(mock_client):
     rs = mock_client.records("alerts")
     assert isinstance(rs, RecordSet)
     assert rs.module == "alerts"
+
+
+# -- upsert / bulk_upsert ---------------------------------------------------
+def test_upsert_posts_to_upsert_path():
+    client = FakeClient({"/api/3/upsert/alerts": {"uuid": "u9", "name": "x"}})
+    rec = RecordSet(client, "alerts").upsert({"name": "x"})
+    assert client.calls[0] == ("POST", "/api/3/upsert/alerts", None, {"name": "x"})
+    assert rec["uuid"] == "u9"
+
+
+def test_upsert_raw_returns_plain_dict():
+    client = FakeClient({"/api/3/upsert/alerts": {"uuid": "u9"}})
+    assert RecordSet(client, "alerts").upsert({"name": "x"}, raw=True) == {"uuid": "u9"}
+
+
+def test_bulk_upsert_posts_list_and_returns_raw():
+    client = FakeClient({"/api/3/bulkupsert/workflow_collections": {"hydra:member": [1, 2]}})
+    rows = [{"name": "a"}, {"name": "b"}]
+    out = RecordSet(client, "workflow_collections").bulk_upsert(rows)
+    method, endpoint, _params, data = client.calls[0]
+    assert (method, endpoint) == ("POST", "/api/3/bulkupsert/workflow_collections")
+    assert data == rows
+    assert out == {"hydra:member": [1, 2]}

--- a/tests/unit/test_wf_tools.py
+++ b/tests/unit/test_wf_tools.py
@@ -1,0 +1,72 @@
+"""Unit tests for WfToolsAPI (Jinja render / global variables)."""
+
+from pyfsr.api.wf_tools import WfToolsAPI
+
+_DYNVARS = {
+    "hydra:member": [
+        {"id": 8, "name": "TTL_Days", "value": "20", "default_value": "20"},
+        {"id": 9, "name": "Region", "value": "us", "default_value": ""},
+    ],
+    "hydra:totalItems": 2,
+}
+
+
+class FakeClient:
+    def __init__(self, *, post_resp=None, get_resp=None):
+        self.post_calls = []
+        self.get_calls = []
+        self._post_resp = post_resp
+        self._get_resp = get_resp
+
+    def post(self, endpoint, data=None, params=None, **kwargs):
+        self.post_calls.append((endpoint, data))
+        return self._post_resp
+
+    def get(self, endpoint, params=None, **kwargs):
+        self.get_calls.append((endpoint, params))
+        return self._get_resp
+
+
+def _api(**kw):
+    c = FakeClient(**kw)
+    return WfToolsAPI(c), c
+
+
+# -- render -----------------------------------------------------------------
+def test_render_unwraps_result():
+    api, client = _api(post_resp={"result": 7})
+    assert api.render("{{ vars.x + 2 }}", {"vars": {"x": 5}}) == 7
+    endpoint, body = client.post_calls[0]
+    assert endpoint == "/api/wf/api/jinja-editor/"
+    assert body == {"template": "{{ vars.x + 2 }}", "values": {"vars": {"x": 5}}}
+
+
+def test_render_defaults_values_to_empty_dict():
+    api, client = _api(post_resp={"result": "hi"})
+    assert api.render("hi") == "hi"
+    assert client.post_calls[0][1]["values"] == {}
+
+
+def test_render_raw_returns_full_envelope():
+    api, _ = _api(post_resp={"result": 7})
+    assert api.render_raw("{{ 7 }}") == {"result": 7}
+
+
+# -- dynamic variables ------------------------------------------------------
+def test_dynamic_variables_returns_members():
+    api, client = _api(get_resp=_DYNVARS)
+    out = api.dynamic_variables()
+    assert [v["name"] for v in out] == ["TTL_Days", "Region"]
+    endpoint, params = client.get_calls[0]
+    assert endpoint == "/api/wf/api/dynamic-variable/"
+    assert params == {"offset": 0, "limit": 2147483647}
+
+
+def test_dynamic_variable_resolves_value_by_name():
+    api, _ = _api(get_resp=_DYNVARS)
+    assert api.dynamic_variable("Region") == "us"
+
+
+def test_dynamic_variable_missing_returns_none():
+    api, _ = _api(get_resp=_DYNVARS)
+    assert api.dynamic_variable("Nope") is None


### PR DESCRIPTION
Closes the five capability gaps identified in the fsrpb → pyfsr migration analysis, so fsr-playbook-framework can consume the SDK instead of re-implementing FortiSOAR access.

## Added
| Area | API |
|------|-----|
| Query | `changed` / `in_all` operators + `Query.changed()` / `Query.in_all()` |
| Records | `RecordSet.upsert()`, `RecordSet.bulk_upsert()` (`/api/3/upsert\|bulkupsert/<m>`) |
| Playbooks | `get(step_detail=True)`, `run_env()` (per-step trace + Jinja run-context) |
| Connectors | `definition()`, `operations()`, `files()` |
| Wf tools | new `client.wf_tools`: `render()` / `render_raw()`, `dynamic_variables()` / `dynamic_variable()` |

## Verification
- Live-verified against the dev box: query ops, `run_env`, connector `operations`, jinja `render`, dynamic variables (endpoint shapes probed before implementation — e.g. the connector definition endpoint forbids GET, takes POST + `?format=json`).
- Upsert write-path is unit-tested with mocks (avoids live side effects).
- 228 unit tests pass (+18); ruff + strict `-W -n` Sphinx clean; CHANGELOG updated.

Backward-compatible: all additions are new methods/operators; no existing signatures changed.