### PR TITLE
Docs version fix + CI-mirroring pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
-# Run `pre-commit install` once; hooks then run on every commit.
-# Update hook versions with `pre-commit autoupdate`.
+# Catch CI failures locally before they reach GitHub.
+#
+# One-time setup (installs BOTH the commit-time and push-time hooks):
+#   pre-commit install
+#   pre-commit install -t pre-push
+#
+# Then: lint/format run on every commit; the heavier tests + strict docs build
+# run on every push. Run everything manually with `pre-commit run -a`.
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.6.9
-    hooks:
-      - id: ruff           # lint (autofix)
-        args: [--fix]
-      - id: ruff-format    # format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -15,3 +15,36 @@ repos:
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict
+
+  # Lint + format with the EXACT ruff pinned in this project (run via uv), so
+  # local results match CI. Using the ruff-pre-commit mirror instead would pin a
+  # second, independent ruff version that can drift from the lockfile and pass
+  # locally while CI's `ruff format --check` fails (which is what bit us).
+  - repo: local
+    hooks:
+      - id: ruff-check
+        name: ruff check (project pin, via uv)
+        entry: uv run ruff check --fix
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+      - id: ruff-format
+        name: ruff format (project pin, via uv)
+        entry: uv run ruff format
+        language: system
+        types_or: [python, pyi]
+        require_serial: true
+
+      # --- pre-push only: mirror the CI jobs that are slow but high-signal ---
+      - id: pytest-unit
+        name: pytest unit suite (mirrors CI test jobs)
+        entry: uv run pytest tests/unit -q -p no:cacheprovider
+        language: system
+        pass_filenames: false
+        stages: [pre-push]
+      - id: docs-build
+        name: sphinx docs build -W -n (mirrors CI docs job; catches broken cross-refs)
+        entry: bash -c 'cd docs && PYTHONPATH=../src uv run make html SPHINXOPTS="-W --keep-going -n"'
+        language: system
+        pass_filenames: false
+        stages: [pre-push]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,14 +1,25 @@
 import os
 import sys
+from datetime import date
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 # Add the src directory to the system path
 sys.path.insert(0, os.path.abspath("../../src"))
 
 # -- Project information -----------------------------------------------------
 project = "pyfsr"
-copyright = "2024, Dylan Spille"
 author = "Dylan Spille"
-release = "0.2.2"
+copyright = f"{date.today().year}, {author}"
+
+# Single source of truth: derive the version from the installed package
+# (hatch-vcs sets it from the git tag), so the docs never drift from a
+# hardcoded number. Falls back gracefully if the package isn't installed.
+try:
+    release = _pkg_version("pyfsr")
+except PackageNotFoundError:  # not installed (e.g. bare checkout)
+    release = "0.0.0+unknown"
+version = ".".join(release.split(".")[:2])  # short X.Y for the header
 
 # Extensions
 extensions = [

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,14 +18,14 @@ Basic Usage:
 
     from pyfsr import FortiSOAR
 
-    # Initialize the client
+    # Initialize the client with an API key
     client = FortiSOAR('your-server', 'your-token')
 
     # or with username and password
     client = FortiSOAR('your-server', ('your-username', 'your-password'))
 
-    # Generic get call to Alerts endpoint
-    response = client.get('/api/v3/alerts')
+    # Generic GET against the v3 API (the path is /api/3/, not /api/v3/)
+    response = client.get('/api/3/alerts')
 
     # Create an alert
     alert_data = {


### PR DESCRIPTION
## What
- **conf.py**: docs version now derives from installed package metadata (hatch-vcs) instead of a hardcoded `0.2.2` (stale by 2 minor versions); copyright year is dynamic.
- **index.rst**: fixed the quickstart generic-GET example — the path is `/api/3/`, not the non-existent `/api/v3/`.
- **.pre-commit-config.yaml**: 
  - Lint/format now run the project's *exact* pinned ruff via `uv` (the old `ruff-pre-commit` mirror pinned an independent ruff that could drift from the lockfile and pass locally while CI's `ruff format --check` failed).
  - Added **pre-push** hooks mirroring the CI jobs that failed during this release: full unit suite + strict sphinx build (`-W -n`, catches broken cross-refs).

## Why
This release had three avoidable CI round-trips (ruff format, then a sphinx `-n` cross-ref error). These hooks catch all of them locally before push.

Setup: `pre-commit install && pre-commit install -t pre-push`