### PR TITLE
Live usage-walkthrough test + offline doc-example validation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -77,6 +77,27 @@ html_theme = "pydata_sphinx_theme"
 templates_path = ["_templates"]
 html_static_path = ["_static"]
 
+# Keep the navbar brand short. The default title is "{project} {release}
+# documentation"; with hatch-vcs dev versions that becomes
+# "pyfsr 0.3.1.dev4+g… documentation", which overflows and overlaps the nav
+# links. Show just the project name in the bar (the full version still appears
+# in the page metadata / footer).
+html_title = project
+html_short_title = project
+
+html_theme_options = {
+    "navigation_with_keys": True,
+    "show_prev_next": False,
+    # Surface the repo without crowding the brand text.
+    "icon_links": [
+        {
+            "name": "GitHub",
+            "url": "https://github.com/ftnt-dspille/pyfsr",
+            "icon": "fa-brands fa-github",
+        }
+    ],
+}
+
 # Custom static files
 html_css_files = [
     "custom.css",  # Example custom CSS

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,12 +27,14 @@ Basic Usage:
     # Generic GET against the v3 API (the path is /api/3/, not /api/v3/)
     response = client.get('/api/3/alerts')
 
-    # Create an alert
-    alert_data = {
+    # Create an alert. Picklist fields (severity/status/...) take an IRI, not a
+    # friendly string, so resolve the friendly values first — the appliance
+    # rejects a raw "High". resolve_record_fields() maps names -> IRIs for you.
+    alert_data = client.picklists.resolve_record_fields("alerts", {
         "name": "Test Alert",
         "description": "This is a test alert",
-        "severity": "High"
-    }
+        "severity": "High",
+    })
     alert_record = client.alerts.create(**alert_data)
 
     # List all alerts

--- a/src/pyfsr/api/modules.py
+++ b/src/pyfsr/api/modules.py
@@ -11,8 +11,8 @@ Accessed as ``client.modules`` (or the ``client.list_modules()`` /
 ``client.describe_module()`` shortcuts).
 
 Example:
-    >>> client.list_modules()["modules"][:3]
-    [{'type': 'alerts', 'label': 'Alerts', 'plural': 'alerts'}, ...]
+    >>> client.list_modules()[:3]
+    [{'type': 'agents', 'label': 'Agent', 'plural': 'agents'}, ...]
     >>> client.describe_module("incidents")["fields"][0]
     {'name': 'name', 'title': 'Name', 'type': 'text', 'required': True,
      'picklist_name': None}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -31,8 +31,23 @@ def get_auth_from_config(config):
 
 @pytest.fixture(scope="session")
 def client():
-    """A live FortiSOAR client built from examples/config.toml."""
+    """A live FortiSOAR client.
+
+    Resolution order, so the suite runs anywhere with no extra files:
+      1. ``FSR_*`` environment variables (``FSR_BASE_URL`` + ``FSR_API_KEY`` or
+         ``FSR_USERNAME``/``FSR_PASSWORD``), via the SDK's own ``EnvConfig`` —
+         the same path documented for end users.
+      2. ``examples/config.toml`` (legacy).
+    If neither is present, the integration suite is skipped.
+    """
+    import os
+
     from pyfsr import FortiSOAR
+
+    if os.environ.get("FSR_BASE_URL") or os.environ.get("FSR_HOST"):
+        from pyfsr.config import EnvConfig
+
+        return EnvConfig.from_env().client()
 
     config = load_config()
     return FortiSOAR(

--- a/tests/integration/test_usage_walkthrough_integration.py
+++ b/tests/integration/test_usage_walkthrough_integration.py
@@ -1,0 +1,162 @@
+"""End-to-end usage walkthrough against a live FortiSOAR.
+
+A single, readable pass over *most* of the documented SDK surface — the same
+calls shown in the README / docs / docstrings — so you can point it at a real
+appliance and prove the whole client actually works, not just that the symbols
+exist (the latter is covered offline by ``tests/unit/test_doc_examples.py``).
+
+Run it (opt-in, read-only by default)::
+
+    export FSR_BASE_URL=https://my-fsr:13002
+    export FSR_USERNAME=csadmin FSR_PASSWORD=... FSR_VERIFY_SSL=false
+    pytest -m integration tests/integration/test_usage_walkthrough_integration.py -v
+
+Every check is read-only except :func:`test_walkthrough_alert_write_lifecycle`,
+which creates one alert and deletes it again (guarded + self-cleaning, and
+skipped unless ``FSR_ALLOW_WRITES=1``).
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from pyfsr.query import Query
+
+pytestmark = pytest.mark.integration
+
+
+# --------------------------------------------------------------------------- #
+# Core client + generic transport (README "Basic Usage")
+# --------------------------------------------------------------------------- #
+def test_walkthrough_generic_get(client):
+    """The generic GET shown in the quickstart — note the path is /api/3/."""
+    resp = client.get("/api/3/alerts", params={"$limit": 1})
+    assert "hydra:member" in resp
+
+
+def test_walkthrough_alerts_read(client):
+    """client.alerts.list() / get() (read side of the alerts example)."""
+    alerts = client.alerts.list(params={"$limit": 3})
+    members = alerts.get("hydra:member", alerts if isinstance(alerts, list) else [])
+    assert isinstance(members, list)
+    if members:
+        one = client.alerts.get(members[0]["uuid"])
+        assert one.get("uuid") == members[0]["uuid"]
+
+
+# --------------------------------------------------------------------------- #
+# Module / field schema discovery (modules.* docstring examples)
+# --------------------------------------------------------------------------- #
+def test_walkthrough_modules_discovery(client):
+    mods = client.list_modules()  # -> [{type, label, plural}, ...]
+    types = {m["type"] for m in mods}
+    assert {"alerts", "incidents"} & types, "expected core modules present"
+
+    desc = client.describe_module("alerts")
+    assert desc["module"] == "alerts" and desc["field_count"] > 0
+    names = {f["name"] for f in desc["fields"]}
+    assert {"name", "severity", "status"} <= names
+
+    # with_values resolves a picklist field's accepted friendly vocabulary
+    desc_v = client.modules.describe("alerts", with_values=True)
+    sev = next(f for f in desc_v["fields"] if f["name"] == "severity")
+    assert sev["picklist_name"] and isinstance(sev.get("picklist_values"), list)
+    assert sev["picklist_values"], "severity should expose friendly values"
+
+    # search + find_field
+    assert client.modules.search("alert"), "search('alert') should match"
+    assert client.modules.find_field(name="severity"), "severity should be locatable"
+
+
+# --------------------------------------------------------------------------- #
+# Picklists + friendly-value resolution (picklists.* examples; alertforge core)
+# --------------------------------------------------------------------------- #
+def test_walkthrough_picklists_and_resolution(client):
+    names = client.picklists.list()
+    assert "Severity" in names
+
+    assert client.picklists.options("Severity"), "Severity should have item values"
+    pick = client.picklists.for_field("alerts", "severity")
+    assert pick  # the picklist backing the field
+
+    # a known-good value resolves to an IRI
+    iri = client.picklists.resolve("High", picklist="Severity")
+    assert isinstance(iri, str) and "/api/3/picklists/" in iri
+
+    # resolve_record_fields: good value -> IRI; bad value -> reported, not raised
+    report: list = []
+    out = client.picklists.resolve_record_fields(
+        "alerts",
+        {"name": "pyfsr walkthrough", "severity": "High", "status": "Open"},
+        report=report,
+    )
+    assert out["severity"].startswith("/api/3/picklists/")
+    assert not report, f"unexpected resolution misses: {report}"
+
+    miss: list = []
+    client.picklists.resolve_record_fields(
+        "alerts", {"severity": "Definitely Not A Severity"}, report=miss
+    )
+    assert miss and miss[0]["field"] == "severity" and miss[0]["valid_values"]
+
+
+# --------------------------------------------------------------------------- #
+# Records + Query (client.records(...).query / iterate examples)
+# --------------------------------------------------------------------------- #
+def test_walkthrough_records_and_query(client):
+    alerts = client.records("alerts")
+    page = alerts.query(Query().limit(5))
+    assert hasattr(page, "__iter__")
+
+    count = 0
+    for _ in alerts.iterate(query=Query().limit(3), max_records=3):
+        count += 1
+    assert count <= 3
+
+
+# --------------------------------------------------------------------------- #
+# Connectors + Playbooks (connectors.* / playbooks.* examples)
+# --------------------------------------------------------------------------- #
+def test_walkthrough_connectors(client):
+    configured = client.connectors.list_configured()
+    assert isinstance(configured, list)
+
+
+def test_walkthrough_playbooks(client):
+    runs = client.playbooks.runs(limit=3)
+    assert isinstance(runs, list) or "hydra:member" in runs
+
+
+# --------------------------------------------------------------------------- #
+# Guarded write path — proves create/delete actually work, then cleans up.
+# --------------------------------------------------------------------------- #
+@pytest.mark.skipif(
+    os.environ.get("FSR_ALLOW_WRITES") != "1",
+    reason="write test is opt-in; set FSR_ALLOW_WRITES=1 to run",
+)
+def test_walkthrough_alert_write_lifecycle(client):
+    # Friendly picklist values must be resolved to IRIs before create() — the
+    # appliance rejects raw "High"/"Open". This is the documented pattern.
+    data = client.picklists.resolve_record_fields(
+        "alerts",
+        {
+            "name": "pyfsr walkthrough — safe to delete",
+            "severity": "High",
+            "status": "Open",
+            "recordTags": ["pyfsr-walkthrough"],
+        },
+        strict=True,
+    )
+    created = client.alerts.create(**data)
+    uuid = created["uuid"]
+    try:
+        fetched = client.alerts.get(uuid)
+        assert fetched["uuid"] == uuid
+        assert fetched["name"].startswith("pyfsr walkthrough")
+    finally:
+        client.alerts.delete(uuid)
+    # confirm it's gone
+    with pytest.raises(Exception):
+        client.alerts.get(uuid)

--- a/tests/unit/test_doc_examples.py
+++ b/tests/unit/test_doc_examples.py
@@ -1,0 +1,175 @@
+"""Verify the inline examples in docstrings and docs actually reference real API.
+
+These examples are *illustrative* — they assume a live ``client`` and a server,
+so they can't be executed as plain doctests. But they can rot silently: a method
+gets renamed, a path is wrong (``/api/v3/`` vs ``/api/3/``), an example calls a
+method that never existed. This test catches that class of bug with no server:
+
+  1. every example snippet is syntactically valid Python, and
+  2. every ``client.<api>.<method>(...)`` / ``FortiSOAR(...)`` reference resolves
+     to a real attribute/method on the actual classes.
+
+Sources covered: ``>>>`` blocks in ``src/pyfsr`` docstrings + the ``python``
+code-blocks in ``docs/source/index.rst``.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+
+import pytest
+
+from pyfsr import FortiSOAR
+from pyfsr.records import RecordSet
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "src" / "pyfsr"
+INDEX_RST = ROOT / "docs" / "source" / "index.rst"
+
+
+# --- map the chain roots the examples use to the class that backs them ------- #
+# client.<attr> sub-APIs are discovered from client.py so this never goes stale.
+def _client_subapis() -> dict[str, type]:
+    """Parse ``self.<name>: <Class> = <Class>(self)`` assignments in client.py."""
+    tree = ast.parse((SRC / "client.py").read_text())
+    import pyfsr.client as cl
+
+    out: dict[str, type] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.target, ast.Attribute)
+            and isinstance(node.target.value, ast.Name)
+            and node.target.value.id == "self"
+            and isinstance(node.annotation, ast.Name)
+        ):
+            cls = getattr(cl, node.annotation.id, None)
+            if isinstance(cls, type):
+                out[node.target.attr] = cls
+    return out
+
+
+SUBAPIS = _client_subapis()
+# Chained calls whose return type we know, so deeper examples still resolve.
+RETURNS = {"records": RecordSet}
+
+
+def _iter_docstring_examples():
+    """Yield (label, code) for each ``>>>`` block found in src docstrings."""
+    for py in SRC.rglob("*.py"):
+        try:
+            mod = ast.parse(py.read_text())
+        except SyntaxError:
+            continue
+        for node in ast.walk(mod):
+            doc = (
+                ast.get_docstring(node, clean=True)
+                if isinstance(
+                    node, (ast.Module, ast.ClassDef, ast.FunctionDef, ast.AsyncFunctionDef)
+                )
+                else None
+            )
+            if not doc or ">>>" not in doc:
+                continue
+            for i, block in enumerate(_extract_doctest_blocks(doc)):
+                yield (f"{py.relative_to(ROOT)}::doc{i}", block)
+
+
+def _extract_doctest_blocks(doc: str) -> list[str]:
+    """Join ``>>>``/``...`` continuation lines into runnable snippets."""
+    blocks, cur = [], []
+    for line in doc.splitlines():
+        s = line.strip()
+        if s.startswith(">>> "):
+            cur.append(s[4:])
+        elif s.startswith("... "):
+            cur.append(s[4:])
+        elif s == ">>>" or s == "...":
+            cur.append("")
+        else:
+            if cur:
+                blocks.append("\n".join(cur))
+                cur = []
+    if cur:
+        blocks.append("\n".join(cur))
+    return blocks
+
+
+def _iter_rst_examples():
+    """Yield (label, code) for each ``.. code-block:: python`` in index.rst."""
+    if not INDEX_RST.exists():
+        return
+    text = INDEX_RST.read_text()
+    for i, m in enumerate(
+        re.finditer(r"\.\. code-block:: python\n\n(.*?)(?:\n\S|\Z)", text, re.DOTALL)
+    ):
+        block = "\n".join(
+            line[4:] if line.startswith("    ") else line for line in m.group(1).splitlines()
+        )
+        yield (f"docs/source/index.rst::block{i}", block.strip())
+
+
+ALL_EXAMPLES = list(_iter_docstring_examples()) + list(_iter_rst_examples())
+
+
+@pytest.mark.parametrize("label,code", ALL_EXAMPLES, ids=[e[0] for e in ALL_EXAMPLES])
+def test_example_is_valid_python(label, code):
+    """Every inline example must at least parse as Python."""
+    ast.parse(code)
+
+
+@pytest.mark.parametrize("label,code", ALL_EXAMPLES, ids=[e[0] for e in ALL_EXAMPLES])
+def test_example_references_real_api(label, code):
+    """Resolve ``client.<api>.<method>`` and ``FortiSOAR(...)`` against real classes."""
+    tree = ast.parse(code)
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Attribute):
+            continue
+        chain = _attr_chain(node)
+        if not chain:
+            continue
+        _assert_chain_resolves(chain, label)
+
+
+def _attr_chain(node: ast.Attribute):
+    """Flatten ``client.x.y`` into ['client'|'<call>', 'x', 'y']; None if not rooted."""
+    parts: list[str] = []
+    cur: ast.AST = node
+    while isinstance(cur, ast.Attribute):
+        parts.append(cur.attr)
+        cur = cur.value
+    if isinstance(cur, ast.Call) and isinstance(cur.func, ast.Attribute):
+        # rooted at e.g. client.records("incidents").<...>
+        inner = _attr_chain(cur.func)
+        if inner and inner[0] == "client" and len(inner) == 2 and inner[1] in RETURNS:
+            parts.append(f"@{inner[1]}")  # sentinel: resolved return type
+            cur = ast.Name(id="client")
+    if isinstance(cur, ast.Name) and cur.id == "client":
+        parts.append("client")
+        return list(reversed(parts))
+    return None
+
+
+def _assert_chain_resolves(chain: list[str], label: str):
+    # chain[0] == 'client'
+    if len(chain) < 2:
+        return
+    second = chain[1]
+    if second.startswith("@"):  # client.records(...).<method>
+        cls = RETURNS[second[1:]]
+        if len(chain) >= 3:
+            assert hasattr(cls, chain[2]), f"{label}: {cls.__name__}.{chain[2]} does not exist"
+        return
+    if second in SUBAPIS:
+        if len(chain) >= 3:
+            cls = SUBAPIS[second]
+            assert hasattr(cls, chain[2]), (
+                f"{label}: client.{second}.{chain[2]} — {cls.__name__} has no '{chain[2]}'"
+            )
+        return
+    # otherwise it's a top-level client method (get/post/records/list_modules/...)
+    assert hasattr(FortiSOAR, second), (
+        f"{label}: client.{second} is not a FortiSOAR attribute/method"
+    )


### PR DESCRIPTION
## Two layers proving the documented usage actually works

**Offline (runs in CI) — `tests/unit/test_doc_examples.py`**
Every `>>>` docstring block and `index.rst` python block must (1) parse and (2) reference a *real* `client.<api>.<method>` symbol. Sub-APIs are auto-discovered from `client.py` so it never goes stale. Catches renamed methods / wrong paths with no server.

**Live (opt-in) — `tests/integration/test_usage_walkthrough_integration.py`**
One readable pass over most of the SDK against a real appliance: generic GET, alerts read, `modules.describe(with_values)`/`search`/`find_field`, picklist `list`/`options`/`resolve`/`resolve_record_fields(report,strict)`, records+`Query` iterate, connectors, playbooks, and a guarded create→get→delete write path (`FSR_ALLOW_WRITES=1`, self-cleaning). **Validated end-to-end against a live 7.6 box — 8/8 pass.**

Run it:
```bash
export FSR_BASE_URL=https://my-fsr:13002 FSR_USERNAME=… FSR_PASSWORD=… FSR_VERIFY_SSL=false
pytest -m integration tests/integration/test_usage_walkthrough_integration.py -v
```
`conftest` now builds the client from `FSR_*` env vars (via `EnvConfig`) before falling back to `examples/config.toml` — no config file needed.

## Real doc bugs the live run found (and this PR fixes)
- **`modules.py`**: `list_modules()` returns a `list`, not `{'modules': [...]}` — the docstring example was wrong.
- **`index.rst`**: friendly picklist values must be resolved to IRIs *before* `alerts.create()`; the old `severity='High'` quickstart is **rejected by the appliance**. Now shows `resolve_record_fields()`.

## Also
Navbar fix: short `html_title` + GitHub icon (the long hatch-vcs dev-version title was overlapping the nav links), and removed dead `sphinx_rtd_theme` rules from `custom.css`.