### PR TITLE
feat(api): system_settings, auth_config, schedules helpers

### DIFF
--- a/examples/tune_new_instance.py
+++ b/examples/tune_new_instance.py
@@ -1,0 +1,72 @@
+"""Apply the standard tuning every brand-new FortiSOAR instance needs.
+
+Repeatable, idempotent settings pass for a fresh appliance. Everything here is
+REST-driven via pyfsr EXCEPT setting the admin password to a non-compliant
+value like "fortinet" — FortiSOAR's password-complexity check rejects that on
+every REST path, so it must be written directly to the DAS user table over the
+appliance shell (see PASSWORD note at the bottom).
+
+Usage:
+    python examples/tune_new_instance.py 10.99.249.159 --port 13002 \
+        --user csadmin --password fortinet
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from pyfsr import FortiSOAR
+
+# Tuning targets ---------------------------------------------------------------
+IDLE_TIMEOUT_MIN = 360          # 6 h — the server-enforced maximum for idle_time
+MAX_SESSION_MIN = 1440          # 24 h absolute session cap
+
+
+def tune(client: FortiSOAR) -> None:
+    # 1. Session/login timeout (DAS auth config) -------------------------------
+    print("auth_config.idle_time   ->", client.auth_config.set_idle_timeout(IDLE_TIMEOUT_MIN))
+    print("auth_config.max_session ->", client.auth_config.set_max_session(MAX_SESSION_MIN))
+
+    # 2. Playbook execution logging --------------------------------------------
+    # Force DEBUG on every run (playbooks can't opt out) and exclude no tags so
+    # the log view shows everything.
+    client.system_settings.set_playbook_debug_logging(True, allow_playbook_override=False)
+    client.system_settings.set_workflow_log_filter([], operation="exclude")
+    pv = client.system_settings.get_public_values()
+    print("system_settings.logs    ->", pv["playbook"]["logs"])
+    print("system_settings.debug   ->", pv["workflow_log_config"])
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("host")
+    ap.add_argument("--port", type=int, default=443)
+    ap.add_argument("--user", default="csadmin")
+    ap.add_argument("--password", required=True)
+    args = ap.parse_args()
+
+    client = FortiSOAR(
+        args.host,
+        (args.user, args.password),
+        verify_ssl=False,
+        suppress_insecure_warnings=True,
+        port=args.port,
+    )
+    tune(client)
+    print("\nDone. Note: setting the admin password to a non-compliant value")
+    print("(e.g. 'fortinet') is NOT possible over REST — run on the appliance:")
+    print(r"""
+  # peppered-bcrypt hash must come from the box's csbcrypt (fixed global pepper):
+  HASH=$(sudo -u cyops-auth /opt/cyops-auth/.env/bin/python3 -c \
+    "import utilities.csbcrypt as b; print(b.CSBcrypt().get_hash('fortinet'))")
+  sudo -u postgres psql -d das -c \
+    "UPDATE users SET password='$HASH' WHERE login_id='csadmin';"
+  # then clear any lockout so the new password takes effect immediately:
+  sudo -u postgres psql -d das -c \
+    "UPDATE userstatus SET status='active', num_failed=0, locked_until=NULL \
+     WHERE user_id=(SELECT id FROM users WHERE login_id='csadmin');"
+""")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/pyfsr/api/auth_config.py
+++ b/src/pyfsr/api/auth_config.py
@@ -1,0 +1,66 @@
+"""Authentication / DAS config — ``/api/auth/config`` (session timeout, 2FA, …).
+
+These settings live in the ``cyops-auth`` (DAS) service, not the PHP platform,
+so they are reached under the ``/api/auth/*`` prefix rather than ``/api/3``.
+The most-tuned values are in the ``TOKEN`` section — idle timeout, token
+lifetime, max session length.
+
+Accessed as ``client.auth_config``. Requires username/password auth (the DAS
+``/api/auth/*`` routes reject API-key auth).
+
+Server-enforced caps (PUT returns HTTP 400 otherwise):
+    * ``idle_time``      ≤ 360  minutes (6 h)
+    * ``token_lifetime`` ≤ 7200 seconds (2 h)
+
+Example:
+    >>> client.auth_config.get("TOKEN")["idle_time"]
+    30
+    >>> client.auth_config.set_idle_timeout(360)        # 6 h — the max
+    >>> client.auth_config.set("max_session", 1440)     # 24 h absolute cap
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .base import BaseAPI
+
+_ENDPOINT = "/api/auth/config"
+
+
+class AuthConfigAPI(BaseAPI):
+    """Read/write the DAS authentication config (``/api/auth/config``)."""
+
+    def get_raw(self, section: str) -> list[dict[str, Any]]:
+        """Return the raw config rows for ``section`` (``TOKEN``, ``PASSWORD``, …).
+
+        Each row is ``{id, section, key, dataType, value}``.
+        """
+        resp = self.client.get(_ENDPOINT, params={"section": section})
+        return (resp or {}).get("hydra:member") or []
+
+    def get(self, section: str) -> dict[str, Any]:
+        """Return a ``{key: value}`` dict for one config ``section``."""
+        return {row["key"]: row["value"] for row in self.get_raw(section)}
+
+    def set(self, option: str, value: Any) -> dict[str, Any]:
+        """Set a single config ``option`` to ``value``.
+
+        ``PUT /api/auth/config`` with ``{"option": ..., "value": ...}``. The
+        server validates bounds and returns ``{"response": "Success"}`` or an
+        HTTP 400 with an ``{"Error": "..."}`` message.
+        """
+        return self.client.put(_ENDPOINT, data={"option": option, "value": value})
+
+    # ------------------------------------------------------------- convenience
+    def set_idle_timeout(self, minutes: int) -> dict[str, Any]:
+        """Idle auto-logout, in minutes (``TOKEN.idle_time``; server cap 360)."""
+        return self.set("idle_time", minutes)
+
+    def set_max_session(self, minutes: int) -> dict[str, Any]:
+        """Absolute session length cap, in minutes (``TOKEN.max_session``)."""
+        return self.set("max_session", minutes)
+
+    def set_token_lifetime(self, seconds: int) -> dict[str, Any]:
+        """JWT lifetime before refresh, in seconds (``TOKEN.token_lifetime``; cap 7200)."""
+        return self.set("token_lifetime", seconds)

--- a/src/pyfsr/api/schedules.py
+++ b/src/pyfsr/api/schedules.py
@@ -1,0 +1,74 @@
+"""Scheduled (periodic) Celery tasks — ``/api/wf/api/scheduled/``.
+
+The workflow engine's recurring jobs (Reclaim Disk Space, Purge Executed
+Playbook Logs, Archive Data, …) are django-celery-beat ``PeriodicTask`` rows.
+This wrapper lists them and toggles ``enabled`` — the common "turn off the
+noisy housekeeping job on a fresh instance" operation.
+
+Accessed as ``client.schedules``.
+
+Note: each row's ``id`` is a per-request Fernet token that decrypts to a stable
+primary key, so always look the task up by ``name`` (the id from one GET is
+fine to PUT back immediately, which is what :meth:`set_enabled` does).
+
+Example:
+    >>> [t["name"] for t in client.schedules.list() if t["enabled"]]
+    ['Reclaim disk space periodically', ...]
+    >>> client.schedules.disable("Reclaim disk space periodically")
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from .base import BaseAPI
+
+_ENDPOINT = "/api/wf/api/scheduled/"
+
+
+class SchedulesAPI(BaseAPI):
+    """List and enable/disable workflow-engine periodic tasks."""
+
+    def list(self) -> list[dict[str, Any]]:
+        """Return all scheduled periodic tasks.
+
+        A single ``limit``-unbounded fetch (the wf API ignores ``page`` but
+        honours ``offset``/``limit``).
+        """
+        resp = self.client.get(
+            _ENDPOINT, params={"format": "json", "offset": 0, "limit": 2147483647}
+        )
+        if isinstance(resp, dict):
+            return resp.get("hydra:member") or resp.get("results") or []
+        return resp or []
+
+    def get(self, name: str) -> dict[str, Any] | None:
+        """Return one scheduled task by exact ``name`` (``None`` if absent)."""
+        for task in self.list():
+            if task.get("name") == name:
+                return task
+        return None
+
+    def set_enabled(self, name: str, enabled: bool) -> dict[str, Any]:
+        """Enable/disable the task named ``name`` and return the updated record.
+
+        The wf API only accepts a full-record ``PUT`` (no PATCH), so this reads
+        the current row, flips ``enabled``, and PUTs it back.
+        """
+        task = self.get(name)
+        if task is None:
+            raise ValueError(f"No scheduled task named {name!r}")
+        body = copy.deepcopy(task)
+        body["enabled"] = enabled
+        return self.client.put(
+            f"{_ENDPOINT}{task['id']}/", data=body, params={"format": "json"}
+        )
+
+    def disable(self, name: str) -> dict[str, Any]:
+        """Disable the task named ``name``."""
+        return self.set_enabled(name, False)
+
+    def enable(self, name: str) -> dict[str, Any]:
+        """Enable the task named ``name``."""
+        return self.set_enabled(name, True)

--- a/src/pyfsr/api/system_settings.py
+++ b/src/pyfsr/api/system_settings.py
@@ -1,0 +1,135 @@
+"""System Settings — the single ``/api/3/system_settings`` configuration blob.
+
+FortiSOAR keeps almost every appliance-wide UI/behaviour toggle in one root
+``SystemSettings`` record whose ``publicValues`` is a deeply-nested dict
+(playbook-log filters, recycle-bin TTL, workflow-log config, themes, …). The
+GUI re-PUTs the *entire* object on every save; this wrapper instead does a
+read / deep-merge / minimal-PUT so callers only specify the keys they want to
+change.
+
+Accessed as ``client.system_settings``.
+
+Example:
+    >>> # Exclude "test"-tagged runs from the playbook execution-log view
+    >>> client.system_settings.set_workflow_log_filter(["test"])
+    >>> # Or merge an arbitrary patch into publicValues
+    >>> client.system_settings.update({"recycleBin": {"enabled": True}})
+"""
+
+from __future__ import annotations
+
+import copy
+from typing import Any
+
+from .base import BaseAPI
+
+_RELATIONSHIPS = {"$relationships": "true"}
+
+
+def _deep_merge(base: dict, patch: dict) -> dict:
+    """Recursively merge ``patch`` into a copy of ``base`` (patch wins).
+
+    Nested dicts are merged key-by-key; every other value (including lists) is
+    replaced wholesale, matching how FortiSOAR stores leaf settings.
+    """
+    out = copy.deepcopy(base)
+    for key, value in patch.items():
+        if isinstance(value, dict) and isinstance(out.get(key), dict):
+            out[key] = _deep_merge(out[key], value)
+        else:
+            out[key] = value
+    return out
+
+
+class SystemSettingsAPI(BaseAPI):
+    """Read and minimally update the root ``SystemSettings`` record."""
+
+    _ENDPOINT = "/api/3/system_settings"
+
+    def get_root(self) -> dict[str, Any]:
+        """Return the root settings record (the one whose ``parent`` is null).
+
+        ``GET /api/3/system_settings?$relationships=true`` returns the root plus
+        its ``sections`` (TAXII, iframe, …); this picks out the root object.
+        """
+        resp = self.client.get(self._ENDPOINT, params=_RELATIONSHIPS)
+        members = (resp or {}).get("hydra:member") or []
+        for record in members:
+            if record.get("parent") is None:
+                return record
+        if members:
+            return members[0]
+        raise ValueError("No system_settings root record returned")
+
+    def get_public_values(self) -> dict[str, Any]:
+        """Return just the root record's ``publicValues`` dict."""
+        return self.get_root().get("publicValues") or {}
+
+    def update(
+        self,
+        public_values_patch: dict[str, Any] | None = None,
+        *,
+        private_values_patch: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Deep-merge patches into the root record and PUT the minimal body.
+
+        Only ``publicValues`` / ``privateValues`` are sent (not the bulky
+        ``sections`` array), which is all the API needs. Returns the updated
+        root record.
+
+        Args:
+            public_values_patch: keys to merge into ``publicValues``.
+            private_values_patch: keys to merge into ``privateValues``.
+        """
+        if not public_values_patch and not private_values_patch:
+            raise ValueError("update() needs at least one patch")
+
+        root = self.get_root()
+        uuid = root["uuid"]
+        body: dict[str, Any] = {}
+        if public_values_patch:
+            body["publicValues"] = _deep_merge(
+                root.get("publicValues") or {}, public_values_patch
+            )
+        if private_values_patch:
+            body["privateValues"] = _deep_merge(
+                root.get("privateValues") or {}, private_values_patch
+            )
+        return self.client.put(
+            f"{self._ENDPOINT}/{uuid}", data=body, params=_RELATIONSHIPS
+        )
+
+    # ------------------------------------------------------------- convenience
+    def set_workflow_log_filter(
+        self, tags: list[str], operation: str = "exclude"
+    ) -> dict[str, Any]:
+        """Set the playbook execution-log tag filter (Settings → Playbooks → Logs).
+
+        ``operation`` is ``"exclude"`` or ``"include"``. Note the FortiSOAR key
+        is the (misspelled) ``filterOpration`` — handled here so callers don't
+        have to reproduce the typo.
+        """
+        if operation not in ("exclude", "include"):
+            raise ValueError("operation must be 'exclude' or 'include'")
+        return self.update(
+            {"playbook": {"logs": {"tags": tags, "filterOpration": operation}}}
+        )
+
+    def set_playbook_debug_logging(
+        self, enabled: bool = True, *, allow_playbook_override: bool = False
+    ) -> dict[str, Any]:
+        """Set the global playbook execution-log verbosity (Settings → Playbooks).
+
+        ``enabled`` turns on full debug logging for every run;
+        ``allow_playbook_override=False`` forces individual playbooks to use the
+        global setting (they can't opt out). Maps to
+        ``publicValues.workflow_log_config``.
+        """
+        return self.update(
+            {
+                "workflow_log_config": {
+                    "debug": enabled,
+                    "allow_pb_to_override": allow_playbook_override,
+                }
+            }
+        )

--- a/src/pyfsr/client.py
+++ b/src/pyfsr/client.py
@@ -11,6 +11,7 @@ from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
 from .api.alerts import AlertsAPI
+from .api.auth_config import AuthConfigAPI
 from .api.connectors import ConnectorsAPI
 from .api.content_hub import ContentHubSearch
 from .api.export_config import ExportConfigAPI
@@ -18,7 +19,9 @@ from .api.modules import ModulesAPI
 from .api.modules_admin import ModulesAdminAPI
 from .api.picklists import PicklistsAPI
 from .api.playbooks import PlaybooksAPI
+from .api.schedules import SchedulesAPI
 from .api.solution_packs import SolutionPackAPI
+from .api.system_settings import SystemSettingsAPI
 from .api.wf_tools import WfToolsAPI
 from .auth.api_key import APIKeyAuth
 from .auth.base import BaseAuth
@@ -205,6 +208,11 @@ class FortiSOAR:
         self.wf_tools: WfToolsAPI = WfToolsAPI(self)
 
         self.solution_packs: SolutionPackAPI = SolutionPackAPI(self, self.export_config)
+
+        # Appliance tuning: system settings, DAS auth config, periodic schedules
+        self.system_settings: SystemSettingsAPI = SystemSettingsAPI(self)
+        self.auth_config: AuthConfigAPI = AuthConfigAPI(self)
+        self.schedules: SchedulesAPI = SchedulesAPI(self)
 
     def _log_request(self, method: str, url: str, params: dict, data: dict, headers: dict) -> None:
         """Log request details when verbose mode is enabled."""


### PR DESCRIPTION
Adds three FortiSOAR appliance-tuning API surfaces to the client.

## What
- **`client.system_settings`** — read / deep-merge / minimal-PUT of the root `SystemSettings` `publicValues` (no need to re-send the giant payload the GUI does). Convenience: `set_workflow_log_filter(tags, operation)`, `set_playbook_debug_logging(enabled, allow_playbook_override)`.
- **`client.auth_config`** — `/api/auth/config` TOKEN/PASSWORD knobs (`set_idle_timeout`, `set_max_session`, `set`); user/pass auth only (DAS rejects API-key on these routes).
- **`client.schedules`** — list / enable / disable workflow-engine periodic tasks (`/api/wf/api/scheduled/`; full-record PUT, paginates via offset/limit).

Plus `examples/tune_new_instance.py`.

## Verified
All three live-verified against a FortiSOAR 8.0 instance (10.99.249.159:13002): settings applied and read back independently; idempotent on re-run.

## Notes
- `system_settings` handles FortiSOAR's misspelled `filterOpration` key.
- `auth_config` server caps observed: `idle_time` ≤ 6h, `token_lifetime` ≤ 2h (not tuned — JWT auto-refreshes).