### PR TITLE
feat(agents,routers): agent lifecycle, installer, connector push + routers

### DIFF
--- a/src/pyfsr/api/agents.py
+++ b/src/pyfsr/api/agents.py
@@ -1,14 +1,27 @@
-"""Agent listing (``/api/3/agents``).
+"""Execution-agent lifecycle + installer (``/api/3/agents`` and ``/api/integration``).
 
 FortiSOAR *agents* are the remote/tenant execution nodes that proxy connector actions. This
-thin wrapper lists them; the ``agentId`` of an active agent is what feeds agent-scoped
-connector lookups (``/api/integration/connector_details/?agent=<id>&active=true``). Accessed
-as ``client.agents``.
+wraps the agent **lifecycle** (list/get/create/delete), the **agent-installer** bundle
+download, and **pushing a connector onto a specific agent**. The ``agentId`` of an active
+agent is what feeds agent-scoped connector lookups
+(``/api/integration/connector_details/?agent=<id>&active=true``). Accessed as
+``client.agents``; the sibling **router** records an agent needs at create time are
+``client.routers`` (see :class:`~pyfsr.api.routers.RoutersAPI`).
+
+Creating a working agent is a two-step dance, mirroring the product:
+
+1. ``create()`` registers the agent record (returns its ``uuid``/``agentId``).
+2. ``installer()`` downloads the per-agent install bundle (a binary ``.bin``) that you then
+   run on the agent host. Connectors can be baked into that bundle, or pushed later with
+   ``install_connector()``.
 
 Example::
 
-    client.agents.list()                  # all agents (raw records)
-    client.agents.list(active_only=True)   # only currently-active agents
+    router = client.routers.first()                      # the configured secure-message router
+    agent = client.agents.create("edge-1", router=router, installer_type="docker")
+    blob = client.agents.installer(agent["agentId"])     # bytes — write to a .bin and run on host
+    client.agents.install_connector(agent["agentId"], name="cyops_utilities", version="3.7.1")
+    client.agents.delete(agent["uuid"])
 """
 
 from __future__ import annotations
@@ -19,18 +32,169 @@ from ..pagination import extract_members
 from .base import BaseAPI
 
 _BASE = "/api/3/agents"
+_AGENT_INSTALLER = "/api/integration/agent-installer/?format=json"
+_INSTALL_CONNECTOR = "/api/integration/install-connector/?format=json"
+
+# ``installerType`` is a system picklist; these are the stable fixture IRIs the in-product
+# editor and the lab provisioner both rely on. Pass one of these keys ("bash"/"docker") to
+# :meth:`AgentsAPI.create`, or a full ``/api/3/picklists/<uuid>`` IRI to override.
+_INSTALLER_PICKLISTS = {
+    "bash": "/api/3/picklists/a8181039-30a0-4807-b470-50de69d37561",
+    "docker": "/api/3/picklists/d9f874be-3068-4282-9aed-100eba51e61b",
+}
+
+_ALL_LIMIT = 2147483647
 
 
 class AgentsAPI(BaseAPI):
-    """List execution agents."""
+    """List, create, delete execution agents; download installers; push connectors."""
 
-    def list(self, *, active_only: bool = False) -> list[dict[str, Any]]:
+    def list(self, *, active_only: bool = False, limit: int = _ALL_LIMIT) -> list[dict[str, Any]]:
         """Return agent records (the ``hydra:member`` array).
 
         ``active_only=True`` filters to agents whose ``active`` flag is truthy. Each record
-        carries at least ``agentId`` and ``active``.
+        carries at least ``uuid``, ``agentId``, and ``active``.
         """
-        members = extract_members(self.client.get(_BASE))
+        members = extract_members(self.client.get(_BASE, params={"$limit": limit}))
         if active_only:
             members = [a for a in members if isinstance(a, dict) and a.get("active")]
         return members
+
+    def get(self, uuid: str) -> dict[str, Any]:
+        """Fetch a single agent record by ``uuid`` (``GET /api/3/agents/{uuid}``)."""
+        uuid = _require_uuid(uuid, "get")
+        return self.client.get(f"{_BASE}/{uuid}")
+
+    def create(
+        self,
+        name: str,
+        *,
+        router: str | dict[str, Any],
+        installer_type: str = "docker",
+        description: str = "",
+    ) -> dict[str, Any]:
+        """Register a new agent (``POST /api/3/agents``); returns the created record.
+
+        ``router`` is the secure-message-exchange router the agent connects through — pass a
+        router record (from :meth:`RoutersAPI.first`/``list``), its ``@id`` IRI, or its bare
+        uuid. ``installer_type`` is ``"docker"`` (default) or ``"bash"``, or a full picklist
+        IRI. Creating the record does **not** install anything; follow with :meth:`installer`.
+        """
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError("create() requires a non-empty agent name")
+        body = {
+            "name": name,
+            "router": _as_router_iri(router),
+            "installerType": _INSTALLER_PICKLISTS.get(installer_type, installer_type),
+            "description": description,
+        }
+        return self.client.post(_BASE, data=body)
+
+    def delete(self, uuid: str) -> None:
+        """Delete an agent record (``DELETE /api/3/agents/{uuid}``). Sends no body."""
+        uuid = _require_uuid(uuid, "delete")
+        self.client.delete(f"{_BASE}/{uuid}")
+
+    def installer(
+        self,
+        agent_id: str,
+        *,
+        connectors: list[Any] | None = None,
+        include_last_known_configurations: bool = False,
+    ) -> bytes:
+        """Download the per-agent install bundle (a binary ``.bin``) as ``bytes``.
+
+        ``POST /api/integration/agent-installer/?format=json``. ``agent_id`` is the agent's
+        ``agentId`` (not its record uuid). ``connectors`` is an optional list of connectors to
+        bake into the bundle; ``include_last_known_configurations`` ships the agent's last
+        known connector configs. Returns the raw bytes — write them to a ``.bin`` and run it
+        on the agent host.
+        """
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise ValueError("installer() requires a non-empty agent_id")
+        body = {
+            "agent": agent_id,
+            "connectors": list(connectors or []),
+            "include_last_known_configurations": bool(include_last_known_configurations),
+        }
+        resp = self.client.request("POST", _AGENT_INSTALLER, data=body)
+        return resp.content
+
+    def install_connector(
+        self,
+        agent_id: str,
+        *,
+        name: str,
+        version: str,
+        label: str | None = None,
+        category: list[str] | None = None,
+        description: str = "",
+        publisher: str = "Fortinet",
+        rpm_full_name: str = "",
+    ) -> dict[str, Any]:
+        """Register/activate a connector on a specific agent.
+
+        ``POST /api/integration/install-connector/?format=json`` — the call the FSoC *Agents →
+        Connectors* view makes so the connector shows as installed on ``agent_id``. ``name``
+        and ``version`` **must match the appliance's connector catalog** (look it up via
+        ``GET /api/integration/connectors/?name=<name>&format=json``); a version the catalog
+        doesn't know returns a bare 500. Poll :meth:`connector_install_status` for progress.
+        """
+        if not isinstance(agent_id, str) or not agent_id.strip():
+            raise ValueError("install_connector() requires a non-empty agent_id")
+        body = {
+            "name": name,
+            "label": label or name,
+            "version": version,
+            "rpm_full_name": rpm_full_name,
+            "category": list(category or []),
+            "description": description,
+            "publisher": publisher,
+            "agent": [agent_id],
+        }
+        return self.client.post(_INSTALL_CONNECTOR, data=body)
+
+    def connector_install_status(
+        self,
+        connector: str,
+        version: str,
+        *,
+        agent_id: str | None = None,
+        active: bool = True,
+    ) -> list[dict[str, Any]]:
+        """Per-agent connector install status rows (awaiting → in-progress → Completed).
+
+        ``POST /api/integration/connectors/agents/<connector>/<version>/?format=json`` — this
+        endpoint is **POST-only** (a GET is forbidden) and an empty body is enough. Returns
+        the list of agent×version rows; pass ``agent_id`` to keep only that agent's row.
+        """
+        path = f"/api/integration/connectors/agents/{connector}/{version}/?format=json"
+        if active:
+            path += "&active=true"
+        rows = self.client.post(path, data={})
+        if isinstance(rows, dict):
+            rows = rows.get("data") or rows.get("hydra:member") or []
+        rows = [r for r in (rows or []) if isinstance(r, dict)]
+        if agent_id is not None:
+            rows = [r for r in rows if r.get("agent") == agent_id]
+        return rows
+
+
+def _require_uuid(uuid: str, op: str) -> str:
+    if not isinstance(uuid, str) or not uuid.strip():
+        raise ValueError(f"{op}() requires a non-empty agent uuid")
+    return uuid.strip()
+
+
+def _as_router_iri(router: str | dict[str, Any]) -> str:
+    """Normalize a router (record dict, ``@id`` IRI, or bare uuid) to its ``/api/3/routers``
+    IRI for the agent create payload."""
+    if isinstance(router, dict):
+        iri = router.get("@id") or router.get("uuid")
+        if not iri:
+            raise ValueError("router dict has neither '@id' nor 'uuid'")
+        router = iri
+    if not isinstance(router, str) or not router.strip():
+        raise ValueError("create() requires a router (record, @id IRI, or uuid)")
+    router = router.strip()
+    return router if router.startswith("/api/") else f"/api/3/routers/{router}"

--- a/src/pyfsr/api/routers.py
+++ b/src/pyfsr/api/routers.py
@@ -1,0 +1,39 @@
+"""Agent router records (``/api/3/routers``).
+
+A *router* is a secure-message-exchange endpoint an execution agent dials into; an agent
+record references one at create time (see :meth:`~pyfsr.api.agents.AgentsAPI.create`). On a
+single-master appliance there is typically exactly one, created by
+``sudo csadm secure-message-exchange enable``. Accessed as ``client.routers``.
+
+Example::
+
+    router = client.routers.first()          # the one configured router, or None
+    client.agents.create("edge-1", router=router)
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..pagination import extract_members
+from .base import BaseAPI
+
+_BASE = "/api/3/routers"
+
+
+class RoutersAPI(BaseAPI):
+    """List the agent secure-message routers."""
+
+    def list(self, *, limit: int = 2147483647) -> list[dict[str, Any]]:
+        """Return router records (the ``hydra:member`` array). Each carries ``@id``,
+        ``uuid``, ``name``, ``address``, ``sni``, and the broker ``certificate`` PEM."""
+        return extract_members(self.client.get(_BASE, params={"$limit": limit}))
+
+    def first(self) -> dict[str, Any] | None:
+        """Return the first router by name (the usual single configured router), or None.
+
+        Raises nothing if none exist — callers that require one (e.g. creating an agent)
+        should check for ``None`` and prompt to enable the secure message exchange.
+        """
+        members = extract_members(self.client.get(_BASE, params={"$limit": 1, "$orderby": "+name"}))
+        return members[0] if members else None

--- a/src/pyfsr/client.py
+++ b/src/pyfsr/client.py
@@ -21,6 +21,7 @@ from .api.modules import ModulesAPI
 from .api.modules_admin import ModulesAdminAPI
 from .api.picklists import PicklistsAPI
 from .api.playbooks import PlaybooksAPI
+from .api.routers import RoutersAPI
 from .api.schedules import SchedulesAPI
 from .api.solution_packs import SolutionPackAPI
 from .api.system_settings import SystemSettingsAPI
@@ -224,9 +225,10 @@ class FortiSOAR:
         self.users: UsersAPI = UsersAPI(self)
         self.ai: AIApi = AIApi(self)
 
-        # Tag names + execution-agent listing
+        # Tag names + execution-agent lifecycle (agents need a router at create time)
         self.tags: TagsAPI = TagsAPI(self)
         self.agents: AgentsAPI = AgentsAPI(self)
+        self.routers: RoutersAPI = RoutersAPI(self)
 
     def _log_request(self, method: str, url: str, params: dict, data: dict, headers: dict) -> None:
         """Log request details when verbose mode is enabled."""

--- a/tests/unit/test_agents_routers.py
+++ b/tests/unit/test_agents_routers.py
@@ -1,0 +1,156 @@
+"""Unit tests for the expanded agents lifecycle/installer + routers wrappers."""
+
+import pytest
+
+from pyfsr.api.agents import AgentsAPI
+from pyfsr.api.routers import RoutersAPI
+
+
+class _Resp:
+    def __init__(self, content=b"", payload=None):
+        self.content = content
+        self._payload = payload
+
+    def json(self):
+        return self._payload
+
+
+class RecordingClient:
+    def __init__(self, *, members=None, post_payload=None, get_payload=None, raw=b""):
+        self.calls = []
+        self._members = members or []
+        self._post_payload = post_payload
+        self._get_payload = get_payload
+        self._raw = raw
+
+    def get(self, endpoint, params=None, **kw):
+        self.calls.append(("GET", endpoint, params))
+        if self._get_payload is not None:
+            return self._get_payload
+        return {"hydra:member": self._members}
+
+    def post(self, endpoint, data=None, params=None, **kw):
+        self.calls.append(("POST", endpoint, data))
+        if self._post_payload is not None:
+            return self._post_payload
+        return {"uuid": "ag-1", **(data or {})}
+
+    def delete(self, endpoint, params=None, **kw):
+        self.calls.append(("DELETE", endpoint, params))
+
+    def request(self, method, endpoint, data=None, **kw):
+        self.calls.append((method, endpoint, data))
+        return _Resp(content=self._raw)
+
+
+# --------------------------------------------------------------------- agents
+def test_agents_get_by_uuid():
+    c = RecordingClient(get_payload={"uuid": "ag-1", "agentId": "a1"})
+    out = AgentsAPI(c).get("ag-1")
+    assert out["agentId"] == "a1"
+    assert c.calls[-1] == ("GET", "/api/3/agents/ag-1", None)
+
+
+def test_agents_list_passes_limit():
+    c = RecordingClient(members=[{"agentId": "a1", "active": True}])
+    AgentsAPI(c).list()
+    assert c.calls[-1][2] == {"$limit": 2147483647}
+
+
+def test_agents_create_normalizes_router_and_installer():
+    c = RecordingClient()
+    AgentsAPI(c).create("edge-1", router="r-uuid", installer_type="docker", description="x")
+    method, endpoint, data = c.calls[-1]
+    assert method == "POST" and endpoint == "/api/3/agents"
+    assert data["name"] == "edge-1" and data["description"] == "x"
+    assert data["router"] == "/api/3/routers/r-uuid"
+    assert data["installerType"] == "/api/3/picklists/d9f874be-3068-4282-9aed-100eba51e61b"
+
+
+def test_agents_create_accepts_router_record_and_iri():
+    c = RecordingClient()
+    api = AgentsAPI(c)
+    api.create("a", router={"@id": "/api/3/routers/abc", "uuid": "abc"})
+    assert c.calls[-1][2]["router"] == "/api/3/routers/abc"
+    api.create("b", router="/api/3/routers/xyz", installer_type="bash")
+    data = c.calls[-1][2]
+    assert data["router"] == "/api/3/routers/xyz"
+    assert data["installerType"] == "/api/3/picklists/a8181039-30a0-4807-b470-50de69d37561"
+
+
+def test_agents_create_requires_name_and_router():
+    c = RecordingClient()
+    with pytest.raises(ValueError):
+        AgentsAPI(c).create("", router="r")
+    with pytest.raises(ValueError):
+        AgentsAPI(c).create("ok", router="")
+
+
+def test_agents_delete_uses_no_body():
+    c = RecordingClient()
+    AgentsAPI(c).delete("ag-1")
+    assert c.calls[-1] == ("DELETE", "/api/3/agents/ag-1", None)
+
+
+def test_agents_installer_returns_bytes():
+    c = RecordingClient(raw=b"MZ\x00binary-bundle")
+    out = AgentsAPI(c).installer("a1", connectors=["cyops_utilities"])
+    assert out == b"MZ\x00binary-bundle"
+    method, endpoint, data = c.calls[-1]
+    assert method == "POST" and endpoint == "/api/integration/agent-installer/?format=json"
+    assert data == {
+        "agent": "a1",
+        "connectors": ["cyops_utilities"],
+        "include_last_known_configurations": False,
+    }
+
+
+def test_agents_install_connector_builds_body():
+    c = RecordingClient(post_payload={"ok": True})
+    AgentsAPI(c).install_connector("a1", name="cyops_utilities", version="3.7.1")
+    method, endpoint, data = c.calls[-1]
+    assert method == "POST" and endpoint == "/api/integration/install-connector/?format=json"
+    assert data["agent"] == ["a1"]
+    assert data["name"] == "cyops_utilities" and data["version"] == "3.7.1"
+    assert data["label"] == "cyops_utilities" and data["publisher"] == "Fortinet"
+
+
+def test_connector_install_status_filters_by_agent():
+    rows = [
+        {"agent": "a1", "status": "Completed"},
+        {"agent": "a2", "status": "awaiting"},
+    ]
+    c = RecordingClient(post_payload=rows)
+    out = AgentsAPI(c).connector_install_status("cyops_utilities", "3.7.1", agent_id="a1")
+    assert out == [{"agent": "a1", "status": "Completed"}]
+    endpoint = c.calls[-1][1]
+    assert endpoint == (
+        "/api/integration/connectors/agents/cyops_utilities/3.7.1/?format=json&active=true"
+    )
+
+
+def test_connector_install_status_unwraps_dict_payload():
+    c = RecordingClient(post_payload={"data": [{"agent": "a1"}]})
+    out = AgentsAPI(c).connector_install_status("c", "1.0", active=False)
+    assert out == [{"agent": "a1"}]
+    assert c.calls[-1][1].endswith("/c/1.0/?format=json")
+
+
+# -------------------------------------------------------------------- routers
+def test_routers_list():
+    c = RecordingClient(members=[{"uuid": "r1", "name": "broker"}])
+    out = RoutersAPI(c).list()
+    assert out == [{"uuid": "r1", "name": "broker"}]
+    assert c.calls[-1] == ("GET", "/api/3/routers", {"$limit": 2147483647})
+
+
+def test_routers_first_orders_by_name():
+    c = RecordingClient(members=[{"uuid": "r1", "name": "broker"}])
+    out = RoutersAPI(c).first()
+    assert out["uuid"] == "r1"
+    assert c.calls[-1][2] == {"$limit": 1, "$orderby": "+name"}
+
+
+def test_routers_first_none_when_empty():
+    c = RecordingClient(members=[])
+    assert RoutersAPI(c).first() is None


### PR DESCRIPTION
## What
Expand the thin `client.agents.list()` wrapper into the full execution-agent surface,
mining the REST contracts out of the lab agent provisioning tool (`provision_agent.py`) —
leaving all the SSH/Docker/VM orchestration behind, per the scope guard.

## Changes
**`client.agents`** (`AgentsAPI`)
- `get(uuid)` / `create(name, router=, installer_type=)` / `delete(uuid)` — full
  `/api/3/agents` lifecycle. `create()` normalizes a router record, `@id` IRI, or bare
  uuid, and maps `installer_type` `bash`/`docker` to the system picklist IRIs.
- `installer(agent_id, connectors=)` — downloads the per-agent install bundle (binary
  `.bin`) as `bytes` via the agent-installer endpoint.
- `install_connector(...)` / `connector_install_status(...)` — register/activate a
  connector on a specific agent and poll its per-agent install status (POST-only endpoint,
  empty body).

**`client.routers`** (new `RoutersAPI`)
- `list()` / `first()` — the secure-message router an agent references at create time.

## Tests
13 new unit tests; full unit suite **405 passed**. Lint clean; docs are autoapi so
`routers` is picked up automatically.

## Caveat
Wrappers are contract-faithful to the (live-battle-tested) provisioner but were not run
against a real agent appliance in this change.