### PR TITLE
docs: fix nitpicky -W cross-reference warnings (unblock PyPI publish)

### DIFF
--- a/src/pyfsr/api/agents.py
+++ b/src/pyfsr/api/agents.py
@@ -76,9 +76,10 @@ class AgentsAPI(BaseAPI):
         """Register a new agent (``POST /api/3/agents``); returns the created record.
 
         ``router`` is the secure-message-exchange router the agent connects through — pass a
-        router record (from :meth:`RoutersAPI.first`/``list``), its ``@id`` IRI, or its bare
-        uuid. ``installer_type`` is ``"docker"`` (default) or ``"bash"``, or a full picklist
-        IRI. Creating the record does **not** install anything; follow with :meth:`installer`.
+        router record (from :meth:`~pyfsr.api.routers.RoutersAPI.first`/``list``), its ``@id``
+        IRI, or its bare uuid. ``installer_type`` is ``"docker"`` (default) or ``"bash"``, or a
+        full picklist IRI. Creating the record does **not** install anything; follow with
+        :meth:`installer`.
         """
         if not isinstance(name, str) or not name.strip():
             raise ValueError("create() requires a non-empty agent name")

--- a/src/pyfsr/api/modules_admin.py
+++ b/src/pyfsr/api/modules_admin.py
@@ -880,7 +880,7 @@ class ModulesAdminAPI(BaseAPI):
         Change is staged until :meth:`publish`.
 
         ``record_uniqueness`` takes plain field names (e.g. ``["name"]``) and is converted
-        to the platform's ``uniqueConstraint`` object shape via :meth:`_unique_constraint`.
+        to the platform's ``uniqueConstraint`` object shape via the ``_unique_constraint`` helper.
         ⚠️ Note: changing record-uniqueness on an **already-published** module requires a
         DB migration that only runs on :meth:`publish`; the staging PUT records the intent
         but the unique index is (re)built at publish time, and removing an existing

--- a/src/pyfsr/api/tags.py
+++ b/src/pyfsr/api/tags.py
@@ -2,8 +2,8 @@
 
 FortiSOAR stores a tag's human name in its ``uuid`` column — there is no separate name
 field — and the list endpoint only returns rows when ``$export=true`` is set. This wrapper
-hides both footguns: :meth:`list` returns plain tag-name strings. Accessed as
-``client.tags``.
+hides both footguns: :meth:`~pyfsr.api.tags.TagsAPI.list` returns plain tag-name strings.
+Accessed as ``client.tags``.
 
 Example::
 

--- a/src/pyfsr/api/workflow_collections.py
+++ b/src/pyfsr/api/workflow_collections.py
@@ -8,11 +8,12 @@ stepping on the load-bearing gotchas below. Accessed as ``client.workflow_collec
 Two shapes are intentionally asymmetric, matching the appliance:
 
 - **create** takes an *import-style envelope* (``{"type": ..., "data": [{...}]}``), the same
-  payload the product's *Import* uses — not a bare record POST. :meth:`create` builds that
-  envelope for you from a name + nested workflows.
+  payload the product's *Import* uses — not a bare record POST.
+  :meth:`~pyfsr.api.workflow_collections.WorkflowCollectionsAPI.create` builds that envelope
+  for you from a name + nested workflows.
 - **delete** must send **no body** and ``$hardDelete=true&$showDeleted=true``. A ``{}`` body
   silently no-ops and leaks the collection; pyfsr's ``client.delete()`` already sends no body,
-  and :meth:`delete` sets the params.
+  and :meth:`~pyfsr.api.workflow_collections.WorkflowCollectionsAPI.delete` sets the params.
 
 Example::
 


### PR DESCRIPTION
The docs build runs with `-W -n` (warnings-as-errors + nitpicky) and gates the PyPI publish (`deploy` needs `test`, which includes the docs job). The docs job isn't a required PR check, so `main` accumulated 5 unresolvable `:meth:` references that fail the build — which is why the v0.4.4 publish run failed before reaching deploy.

Fixes all 5 by qualifying the references with full dotted paths (and making the private `_unique_constraint` ref plain code, since autoapi emits no target for private members). Local `sphinx-build -b html -W -n` now succeeds with 0 warnings.