### PR TITLE
feat(connectors): add find_installed_connectors partial-match search

### DIFF
--- a/src/pyfsr/api/connectors.py
+++ b/src/pyfsr/api/connectors.py
@@ -40,6 +40,7 @@ Example:
 from __future__ import annotations
 
 import mimetypes
+import re
 import time
 from pathlib import Path
 from typing import Any
@@ -322,6 +323,40 @@ class ConnectorsAPI(BaseAPI):
 
     def _find_configured(self, connector: str) -> dict[str, Any] | None:
         return next((c for c in self.list_configured() if c.get("name") == connector), None)
+
+    def find_installed_connectors(self, query: str) -> list[dict[str, Any]]:
+        """Search *installed* connectors by partial, case-insensitive match.
+
+        Scoped to connectors installed on this appliance (the
+        :meth:`list_configured` set) — it does **not** see the Content Hub
+        catalog of installable-but-not-installed connectors. For that, use
+        ``client.content_hub.search_available_connectors(...)``.
+
+        Matches ``query`` as a substring of either the connector ``name`` or its
+        ``label`` — so ``"fortigate"`` finds ``fortigate-firewall`` (label
+        ``"Fortinet FortiGate"``) regardless of hyphen/underscore or casing.
+        Returns the matching :meth:`list_configured` entries (possibly empty),
+        ordered with exact ``name`` matches first.
+
+        Useful when you don't know a connector's exact machine name — note that
+        :meth:`resolve_version` and friends require the exact ``name``, while the
+        human-facing label differs (``"Fortinet FortiGate"`` vs
+        ``"fortigate-firewall"``).
+        """
+
+        def norm(s: str) -> str:
+            # fold case and treat '-', '_', and whitespace as interchangeable so
+            # 'fortigate_firewall', 'FortiGate', and 'forti gate' all match.
+            return re.sub(r"[-_\s]+", "-", (s or "").strip().lower())
+
+        q = norm(query)
+        hits = [
+            c
+            for c in self.list_configured()
+            if q in norm(c.get("name")) or q in norm(c.get("label"))
+        ]
+        hits.sort(key=lambda c: norm(c.get("name")) != q)
+        return hits
 
     def configurations(self, connector: str) -> list[dict[str, Any]]:
         """List a connector's configurations (``[{config_id, name, default}]``)."""

--- a/tests/unit/test_connectors.py
+++ b/tests/unit/test_connectors.py
@@ -95,6 +95,35 @@ def test_resolve_version():
     assert api.resolve_version("nope") is None
 
 
+def test_find_installed_connectors_partial_and_label():
+    api, _ = _api()
+    # case-insensitive substring on name
+    assert [c["name"] for c in api.find_installed_connectors("forti")] == [
+        "fortigate",
+        "fortinet-fortisiem",
+    ]
+    # substring on label (name has no "virus")
+    assert [c["name"] for c in api.find_installed_connectors("virus")] == ["virustotal"]
+    # no match -> empty
+    assert api.find_installed_connectors("nope") == []
+
+
+def test_find_installed_connectors_separator_and_case_folding():
+    api, _ = _api()
+    # underscores/spaces/casing fold to the hyphenated name
+    assert [c["name"] for c in api.find_installed_connectors("Fortinet_FortiSIEM")] == [
+        "fortinet-fortisiem"
+    ]
+
+
+def test_find_installed_connectors_exact_name_sorts_first():
+    api, _ = _api()
+    # "fortigate" is an exact name and also a prefix of nothing else here, but
+    # it must rank ahead of any non-exact match for the same query token.
+    hits = api.find_installed_connectors("fortigate")
+    assert hits[0]["name"] == "fortigate"
+
+
 def test_resolve_config_default_and_named():
     api, _ = _api()
     assert api.resolve_config("virustotal") == "vt-default"  # default flag


### PR DESCRIPTION
## What

Adds `ConnectorsAPI.find_installed_connectors(query)` — a case- and separator-insensitive substring search over installed connectors' `name` and `label`.

So `find_installed_connectors("fortigate")`, `"fortigate_firewall"`, and `"FortiGate"` all resolve to the installed `fortigate-firewall` (label `Fortinet FortiGate`). Exact `name` matches sort first.

## Why

`resolve_version` and friends require the **exact** machine name (`fortigate-firewall`), which differs from both the human label and common guesses (underscore vs hyphen). This gives a discovery front-door so callers don't have to guess.

## Scope

Installed-only (`list_configured`). The Content Hub catalog stays behind `content_hub.search_available_connectors(...)`; the docstring points there.

## Tests

3 new unit tests (partial/label match, separator+case folding, exact-first ordering). Full connector suite: 48 passed.