### PR TITLE
ci: harden pipeline (pin sphinx, weekly run, dependabot, concurrency)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Keep pinned action SHAs current (security + bugfix bumps as reviewable PRs).
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]
+    commit-message:
+      prefix: "ci"
+
+  # Surface breaking runtime/dev dependency bumps as PRs (CI runs against them)
+  # instead of discovering them at release time. Grouped to limit PR noise.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      python-deps:
+        patterns: ["*"]
+    commit-message:
+      prefix: "deps"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.10'
+          # Sphinx >=9.1 (the pinned docs-gate version) requires Python >=3.12.
+          python-version: '3.12'
 
       - name: Cache pip dependencies
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -14,6 +14,17 @@ on:
         required: false
         type: string
         description: 'The Git ref to checkout'
+  # Weekly run on main so unpinned (`>=`) runtime/docs deps that break the build
+  # surface on a schedule, not at release time. Mondays 07:00 UTC.
+  schedule:
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+# Cancel superseded runs for the same PR/branch to save CI minutes; never cancel
+# scheduled or release (workflow_call) runs.
+concurrency:
+  group: tests-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: write
@@ -80,5 +91,7 @@ jobs:
       contents: write
     uses: ./.github/workflows/docs.yml
     with:
-      ref: ${{ github.event.pull_request.head.sha }}
+      # Fall back to the triggering ref for schedule / workflow_dispatch /
+      # workflow_call runs, which have no pull_request context.
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
     secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,10 +42,15 @@ typecheck = [
     "mypy>=1.13",
 ]
 
+# Sphinx is bound to a single major (>=9.1,<10): the nitpicky `-W -n` docs gate
+# is version-sensitive (8.x rejects type-alias xrefs that 9.x resolves), so an
+# unbounded floor let CI (8.1.3) and dev machines (9.1) diverge and produce
+# false-green pre-push hooks. Keep the floor == what the docs gate is verified
+# against; bump deliberately, not implicitly.
 docs = [
-    "sphinx>=8.1.3",
+    "sphinx>=9.1,<10",
     "sphinx-autodoc-typehints>=3.0.0",
-    "sphinx-autoapi>=3.4.0",
+    "sphinx-autoapi>=3.8,<4",
     "furo>=2024.8.6",
     "sphinx-design>=0.6.1",
     "sphinx-copybutton>=0.5.2",


### PR DESCRIPTION
Hardening after the v0.7.5 release-time docs failure (CI sphinx 8.1.3 vs local 9.1.0 diverged on the version-sensitive \`-W -n\` gate, so the pre-push hook went false-green).

## Changes
- **Pin sphinx** to \`>=9.1,<10\` + \`sphinx-autoapi>=3.8,<4\` so CI installs the same major the docs gate / pre-push hook are verified against.
- **Weekly cron** (Mon 07:00 UTC) + \`workflow_dispatch\` on pr-tests, so unpinned (\`>=\`) deps that break the build surface on a schedule rather than at release time.
- **concurrency** group cancels superseded PR runs (not schedule/release runs).
- docs sub-call \`ref\` falls back to \`github.sha\` for non-PR triggers.
- **\`.github/dependabot.yml\`**: weekly grouped bumps for github-actions + pip.

## Verified
- Docs build green under the pinned sphinx (9.1.0).
- YAML parses; this PR's own CI run exercises the new workflow config.

Note: branch protection on \`main\` is currently disabled — proposed separately.