### PR TITLE
models: add EmailTemplate + Team relationship fields (actors/parents/siblings/children)

### DIFF
--- a/src/pyfsr/models/__init__.py
+++ b/src/pyfsr/models/__init__.py
@@ -69,6 +69,7 @@ from ._system import (
     ConnectorVersionInfo,
     ContentHubConnector,
     ContentHubItem,
+    EmailTemplate,
     ExportConnectorRef,
     ExportOptions,
     ExportTemplate,
@@ -103,6 +104,7 @@ MODEL_REGISTRY: dict[str, type[BaseRecord]] = {
     "files": FileRecord,
     "people": User,
     "teams": Team,
+    "email_templates": EmailTemplate,
     "roles": Role,
     "api_keys": ApiKey,
 }
@@ -168,6 +170,7 @@ __all__ = [
     "ExportConnectorRef",
     "User",
     "Team",
+    "EmailTemplate",
     "Role",
     "ModulePermission",
     "ApiKey",

--- a/src/pyfsr/models/_system.py
+++ b/src/pyfsr/models/_system.py
@@ -263,6 +263,25 @@ class Team(BaseRecord):
     name: str | None = None
     description: str | None = None
     importedBy: list[Any] | None = None
+    actors: list[User | str] | None = None  # member people; expanded User per $relationships=true
+    parents: list[Any] | None = None
+    siblings: list[Any] | None = None
+    children: list[Any] | None = None
+
+
+class EmailTemplate(BaseRecord):
+    """A FortiSOAR **email template** record from ``/api/3/email_templates/``.
+
+    Reusable subject/body used by notification playbooks and the SMTP connector's
+    "Email Template" body type. The module slug is ``email_templates``; ``@type``
+    on the wire is ``EmailTemplate``. ``subject`` and ``content`` may contain
+    Jinja that the platform expands at send time (verified against a live 8.0 box).
+    """
+
+    name: str | None = None
+    subject: str | None = None
+    content: str | None = None
+    visible: bool | None = None
 
 
 class ModulePermission(BaseRecord):

--- a/tests/unit/test_system_models.py
+++ b/tests/unit/test_system_models.py
@@ -44,6 +44,48 @@ def test_model_for_workflows():
     assert model_for("workflow_collections") is WorkflowCollection
 
 
+# -- EmailTemplate model + Team.actors (live shapes from an 8.0 box) ---------
+def test_email_template_model_and_registry():
+    from pyfsr.models import EmailTemplate
+
+    assert model_for("email_templates") is EmailTemplate
+    assert MODEL_REGISTRY["email_templates"] is EmailTemplate
+    tpl = EmailTemplate.model_validate(
+        {
+            "@id": "/api/3/email_templates/12f23d8d",
+            "@type": "EmailTemplate",
+            "name": "System: Send email to new user",
+            "subject": "FortiSOAR password reset",
+            "content": "<p>Hi {{user}}</p>",
+            "visible": True,
+        }
+    )
+    assert tpl.name == "System: Send email to new user"
+    assert tpl.subject == "FortiSOAR password reset"
+    assert tpl.iri == "/api/3/email_templates/12f23d8d"
+    assert tpl["content"] == "<p>Hi {{user}}</p>"  # dict access compat
+
+
+def test_team_actors_expand_to_users_with_relationships():
+    from pyfsr.models import Team
+
+    team = Team.model_validate(
+        {
+            "@id": "/api/3/teams/t-1",
+            "@type": "Team",
+            "name": "SOC Team",
+            "actors": [
+                {"@id": "/api/3/people/u-1", "@type": "Person", "email": "admin@example.com"},
+                "/api/3/people/u-2",  # IRI string when relationships not expanded
+            ],
+        }
+    )
+    assert team.name == "SOC Team"
+    expanded, ref = team.actors
+    assert expanded.email == "admin@example.com"  # parsed into a User
+    assert ref == "/api/3/people/u-2"  # bare IRI kept as str
+
+
 # -- Workflow / WorkflowCollection models -----------------------------------
 def test_workflow_typed_fields_and_dict_compat():
     wf = Workflow.model_validate(


### PR DESCRIPTION
## What

Adds the two FortiSOAR model shapes that were missing/incomplete, found while building a new SMTP connector that resolves Team recipients and Email Template bodies.

- **EmailTemplate** model for /api/3/email_templates (@type EmailTemplate): name, subject, content, visible. Registered under the email_templates slug, so model_for('email_templates') now returns it instead of BaseRecord.
- **Team** gains its relationship collections: actors (member people, expanded to User with $relationships=true, or IRI strings otherwise), plus parents/siblings/children.

## Verification

Shapes captured from a live FortiSOAR 8.0 box (fsr130). New tests cover the registry entry, EmailTemplate parsing (incl. dict-access compat), and Team.actors mixed expanded/IRI parsing. The 7 unrelated test_playbook_build_surface failures pre-exist on main.