### PR TITLE
fix(library): resolve 3 residual playbook errors (no decompiler bugs)

### DIFF
--- a/examples/playbooks/library/action/ai-enrichment-openai.yaml
+++ b/examples/playbooks/library/action/ai-enrichment-openai.yaml
@@ -9,10 +9,6 @@
 # outputs: a comment / record update on the source record
 # connectors: see connector steps (connector-pluggable; swap the config for your appliance)
 # adapts-to: the SOC intent named above; retarget by changing the module + inputs.
-# NOTE: 1 non-connector blocking error(s) remain after cleaning:
-#   - bad_value: param 'max_tokens' on openai.chat_completions is type 'integer'
-#     but got '' (str) which does not coerce to int (decompiler emitted an empty
-#     string for an unset integer param). Fix by dropping the field or passing an int.
 
 collection: 00. Playbook Learning SP - Specific Playbooks
 description: ''
@@ -101,7 +97,6 @@ playbooks:
         top_p: ''
         message: '{{vars.final_query}}'
         timeout: 600
-        max_tokens: ''
         temperature: ''
         other_fields: ''
       connector: openai

--- a/examples/playbooks/library/action/host-containment-isolate.yaml
+++ b/examples/playbooks/library/action/host-containment-isolate.yaml
@@ -6,10 +6,6 @@
 # outputs: a tag on the alert, asset record updated, notification sent
 # connectors: activedirectory (swap-in connector step)
 # adapts-to: host containment remediation intent
-# NOTE: 1 non-connector blocking error(s) remain after cleaning:
-#   - unknown_operation: operation 'disable_account' on connector 'activedirectory'
-#     is not defined in the catalog (suggestion: 'disable_user_account'). Rename
-#     the operation to one present on your target appliance's AD connector.
 
 collection: 00. Playbook Learning SP - Specific Playbooks
 description: ''
@@ -41,9 +37,10 @@ playbooks:
       name: Active Directory
       config: <replace-with-your-config-uuid>
       params:
-        account: "{{ vars.host_name }}"
+        search_attr_name: "SamAccount Name"
+        search_attr_value: "{{ vars.host_name }}"
       connector: activedirectory
-      operation: disable_account
+      operation: disable_user_account
       operationTitle: Disable AD Account
     next: Add Containment Tag
 

--- a/examples/playbooks/library/action/quarantine-ip-fortigate.yaml
+++ b/examples/playbooks/library/action/quarantine-ip-fortigate.yaml
@@ -10,7 +10,14 @@
 # connectors: see connector steps (connector-pluggable; swap the config for your appliance)
 # adapts-to: the SOC intent named above; retarget by changing the module + inputs.
 # NOTE: 1 non-connector blocking error(s) remain after cleaning:
-#   - bad_value: Jinja reference vars.steps.Approval_Request.username in step 'user_who_approved': step 'Ap
+#   - bad_value: Jinja reference vars.steps.Approval_Request.username in step
+#     'user_who_approved': step 'Approval_Request' cannot run before
+#     'user_who_approved' in any execution path. This decompiled playbook keeps
+#     the legacy ApprovalManualInput step type; its button→step branches live in
+#     arguments.response_mapping (step_iri), which the resolver does not promote
+#     to friendly edges (only the friendly manual_input type does, per
+#     normalizers.py L133). Re-clean with a decompiler that emits friendly
+#     manual_input, or convert the step by hand. Not a decompiler bug (faithful).
 
 collection: 00. Playbook Learning SP - Specific Playbooks
 description: ''

--- a/examples/playbooks/library/enrichment/ad-lookup-by-email.yaml
+++ b/examples/playbooks/library/enrichment/ad-lookup-by-email.yaml
@@ -9,10 +9,6 @@
 # outputs: a comment / record update on the source record
 # connectors: see connector steps (connector-pluggable; swap the config for your appliance)
 # adapts-to: the SOC intent named above; retarget by changing the module + inputs.
-# NOTE: 1 non-connector blocking error(s) remain after cleaning:
-#   - bad_value: param 'size_limit' on activedirectory.global_search is type 'integer'
-#     but got '' (str) which does not coerce to int (decompiler emitted an empty
-#     string for an unset integer param). Fix by dropping the field or passing an int.
 
 collection: 00. Playbook Learning SP - Specific Playbooks
 description: ''
@@ -51,8 +47,6 @@ playbooks:
       config: 65262d44-9202-4501-bc06-9e5b3ef5c9c5
       params:
         cookie: ''
-        page_size: ''
-        size_limit: ''
         search_object: User
         search_attr_name: Email
         search_attr_value: '{{vars.input.records[0].value}}'

--- a/examples/playbooks/library/enrichment/multi-source-ip-reputation-rollup.yaml
+++ b/examples/playbooks/library/enrichment/multi-source-ip-reputation-rollup.yaml
@@ -10,7 +10,11 @@
 # connectors: see connector steps (connector-pluggable; swap the config for your appliance)
 # adapts-to: the SOC intent named above; retarget by changing the module + inputs.
 # NOTE: 1 non-connector blocking error(s) remain after cleaning:
-#   - bad_value: param 'relationships' on virustotal.query_ip: value '' not in enum. Allowed: 'Comments', '
+#   - bad_value: Jinja reference vars.steps.Enter_IP.input.iP in step 'fgt_block':
+#     step 'Enter_IP' cannot run before 'fgt_block' in any execution path. This
+#     decompiled playbook's step graph predates the current clean pipeline; the
+#     decision/approval branches need re-resolving. Not a decompiler bug
+#     (fresh decompile is faithful); needs a re-clean.
 
 collection: 00. Playbook Learning SP
 description: ''
@@ -285,7 +289,6 @@ playbooks:
       config: 2df52cf6-e4e2-4eee-bce1-7fc6d22d9fc1
       params:
         ip: '{{vars.steps.Enter_IP.input.iP}}'
-        relationships: ''
       connector: virustotal
       operation: query_ip
       operationTitle: Get IP Reputation

--- a/examples/playbooks/library/manifest.json
+++ b/examples/playbooks/library/manifest.json
@@ -25,7 +25,7 @@
       "triggers": [
         "start"
       ],
-      "compiles_ok": false
+      "compiles_ok": true
     },
     {
       "slug": "change-incident-lead-critical",
@@ -146,7 +146,7 @@
       "triggers": [
         "start"
       ],
-      "compiles_ok": false
+      "compiles_ok": true
     },
     {
       "slug": "parent-calls-child-workflow-reference",
@@ -363,7 +363,7 @@
       "triggers": [
         "start"
       ],
-      "compiles_ok": false
+      "compiles_ok": true
     },
     {
       "slug": "enrich-indicator-extract-artifacts-rollup",


### PR DESCRIPTION
## Summary

Root-caused all 5 library playbook residuals against the canonical tutorial-corpus source **before fixing**, to confirm none are decompiler bugs. **Confirmed: zero decompiler bugs.** Then fixed the 3 that are safe to hand-patch.

### Root-cause findings (canonical source verified)
- **ai-enrichment-openai** (`max_tokens: ''`), **ad-lookup-by-email** (`size_limit: ''`), **multi-source** (`relationships: ''`): the canonical FortiSOAR export genuinely has empty-string params — the tutorial author left optional params blank in the UI and FSR exports that as `''`. The decompiler faithfully round-trips `''` → `''` (verified via fresh re-decompile reproducing it exactly). The pyfsr compiler is just stricter than FSR's runtime (rejects `''` for int/enum). **Fix: drop the empty-string fields** (semantically = unset).
- **host-containment-isolate** (`disable_account` op): AUTHORED playbook (not in tutorial corpus) — a typo. The real op is `disable_user_account`, which takes `search_attr_name` (select: `SamAccount Name`/`Email`) + `search_attr_value`. **Fix: bind `vars.host_name` → `search_attr_value`.**

### Result: 22 → 25 of 27 compile
The 3 above now compile clean.

### 2 remain — documented honestly, not hand-patched
- **quarantine-ip-fortigate** + **multi-source-ip-reputation-rollup**: stale decompiled library YAML predating the current clean pipeline. **Fresh re-decompile is faithful (NOT a decompiler bug)**, but the legacy `ApprovalManualInput` step's button→step branches live in `arguments.response_mapping` (step_iri), which the resolver only promotes to friendly edges for the `manual_input` type (`normalizers.py` L133), not the legacy type. NOTE headers updated to document this; these need a re-clean, not a hand-patch.

## Test plan
- [x] 25/27 library playbooks compile offline (was 22)
- [x] `make doctest` — 103/103
- [x] `check_doc_examples.py` — 0 issues
- [x] `exec_cli_examples.py` — 37/37 (was 34)
- [x] Fresh re-decompile reproduces `max_tokens: ''` etc. exactly (decompiler faithful)
- [x] Pre-commit "no leaked IPs / credentials" hook passes