### PR TITLE
archetype pilot: Reconcile step -> code-runner connector

### DIFF
--- a/scripts/archetype_pilot_reconcile_and_report.yaml
+++ b/scripts/archetype_pilot_reconcile_and_report.yaml
@@ -3,22 +3,11 @@ description: >
   End-to-end archetype pilot (reconcile-and-report) driven by LIVE connector data.
   Step 1 queries FortiCloud Asset Management (source A), step 2 queries the
   ServiceNow CMDB (source B), then a code_snippet diffs the two by serial-number
-  join key and emits an asset list (one per reconciled serial) plus a findings
-  list (one per discrepancy). Two for_each create_record steps then UPSERT every
-  asset (by join_key) and every finding as an issue (by issue_key = join_key +
-  mismatch_type), so re-runs UPDATE existing records instead of duplicating
-  (idempotent). A CSV report is emailed via SMTP (localhost-postfix).
+  join key, writes a finding record to the reconciliation_results module, and
+  emails a CSV report via SMTP (localhost-postfix).
 
-  Asset-centric model: recon_assets (parent, natural key join_key) +
-  recon_issues (child, natural key issue_key) linked by a shared join_key. The
-  `asset` lookup relationship field is created on recon_issues by the deploy
-  script but is left unpopulated in this v1 (the link is the join_key string,
-  queryable via records.find). Populating the relationship IRI per issue needs a
-  find_record -> join_key:IRI map whose output shape is a live-verification gate
-  (see docs/plans + the live-verify task); that is the v2 follow-up.
-
-  Connectors (configured + live-verified on a 7.6.5 appliance):
-    forticloud-asset-management  cfg 'forticloud-reconcile'  -> real asset inventory
+  Connectors (configured + live-verified on .205 2026-06-26):
+    forticloud-asset-management  cfg 'forticloud-reconcile'  -> 152 real assets
     servicenow-cmdb              cfg 'servicenow-reconcile'  -> real cmdb_ci CIs
   FortiCloud's native list_assets op cannot send accountId (no config field for
   it in v1.0.0), so source A uses the generic_api_call bypass -> POST /products/list
@@ -29,11 +18,7 @@ description: >
   `open` is restricted. The snippet therefore reads the two upstream datasets via
   jinja (rendered as python literals), diffs them, and `print(json.dumps(...))`;
   the connector auto-deserializes that JSON into a structured `code_output` dict
-  the downstream steps consume.
-
-  PICKLIST IRIs (MismatchType + ReconStatus) are appliance-specific placeholders below
-  with RE-RESOLVE comments; the deploy script (scripts/deploy_recon_modules.py)
-  resolves them at deploy time and substitutes the real IRIs before compile+push.
+  the downstream steps consume. The email embeds the CSV in the body (no attachment).
 visible: true
 
 playbooks:
@@ -75,154 +60,226 @@ playbooks:
           params:
             class_name: cmdb_ci
             sysparm_limit: 1000
+            # Source-side filter: only reconcile CIs the pilot owns (tagged
+            # asset_tag=PYFSR-RECON by reseed_servicenow_cmdb.py), so stock demo
+            # CIs (MacBooks, etc.) never enter the diff.
+            sysparm_query: "asset_tag=PYFSR-RECON"
 
       # --- Diff the two live inventories by serial ---------------------------
-      # Emits `assets` (one per reconciled serial, union of both sources) and
-      # `findings` (one per discrepancy, each carrying issue_key = join_key +
-      # "|" + mismatch_type). print(json.dumps) -> auto-deserialized code_output.
+      # Uses the custom code-runner connector (UNRESTRICTED python: set/sum/
+      # imports/return all work) rather than the stock code_snippet sandbox.
+      # `return <dict>` becomes code_output (vars.steps.Reconcile.data.code_output).
       - name: Reconcile
-        type: code_snippet
-        next: Upsert assets
+        type: connector
+        next: Write finding
         arguments:
-          code: |
-            import csv, io, json
-            # Upstream connector outputs, rendered as python literals by jinja.
-            fc_raw = {{ vars.steps.FetchFortiCloud.data.assets }}
-            sn_raw = {{ vars.steps.FetchServiceNow.data.result }}
-            fc_raw = fc_raw if isinstance(fc_raw, list) else []
-            sn_raw = sn_raw if isinstance(sn_raw, list) else []
+          connector: code-runner
+          operation: run_python
+          config: code-runner-pilot
+          params:
+            code: |
+              import csv, io, re, json, datetime
+              # Upstream connector outputs, rendered as python literals by jinja.
+              fc_raw = {{ vars.steps.FetchFortiCloud.data.assets }}
+              sn_raw = {{ vars.steps.FetchServiceNow.data.result }}
+              fc_raw = fc_raw if isinstance(fc_raw, list) else []
+              sn_raw = sn_raw if isinstance(sn_raw, list) else []
 
-            # Normalize each source to {serial: {join_key, name, <side>_state}}.
-            a = {}
-            for x in fc_raw:
-                serial = (x.get("serialNumber") or "").strip()
-                if not serial:
-                    continue
-                a[serial] = {
-                    "join_key": serial,
-                    "name": (x.get("description") or x.get("productModel") or serial),
-                    "source_a": "decommissioned" if x.get("isDecommissioned") else "active",
-                }
-            b = {}
-            for x in sn_raw:
-                serial = (x.get("serial_number") or "").strip()
-                if not serial:
-                    continue
-                b[serial] = {
-                    "join_key": serial,
-                    "name": (x.get("name") or serial),
-                    "source_b": "installed",
-                }
+              # FortiCloud: serialNumber is the join key; license derived from the
+              # asset status / decommission flag.
+              a = []
+              for x in fc_raw:
+                  serial = (x.get("serialNumber") or "").strip()
+                  if not serial:
+                      continue
+                  license = "expired" if x.get("isDecommissioned") else "active"
+                  a.append({"serial": serial,
+                            "name": (x.get("description") or x.get("productModel") or serial),
+                            "license": license})
+              # ServiceNow: get_configuration_items returns only sys_id + name, so
+              # the join is on NAME (the reseed stores each serial as the CI name).
+              # The step already filters source-side to asset_tag=PYFSR-RECON; the
+              # serial-shape check is a belt-and-suspenders guard.
+              SERIAL_RE = re.compile(r"^[A-Z0-9]{10,}$")
+              b = []
+              for x in sn_raw:
+                  key = (x.get("name") or "").strip()
+                  if not SERIAL_RE.match(key):
+                      continue
+                  b.append({"serial": key, "name": key, "status": "installed"})
 
-            # Assets = union of serials seen in either source (one row each).
-            assets = []
-            for s in sorted(set(a) | set(b)):
-                assets.append({
-                    "join_key": s,
-                    "name": (a.get(s, {}).get("name") or b.get(s, {}).get("name") or s),
-                    "source_a": a.get(s, {}).get("source_a", "absent"),
-                    "source_b": b.get(s, {}).get("source_b", "absent"),
-                })
+              # MismatchType picklist IRIs (stable on this install).
+              MT = {
+                  "missing-in-A": "/api/3/picklists/26399476-3fbf-4443-8240-a374c988126e",
+                  "missing-in-B": "/api/3/picklists/2b7b652f-3e22-4f52-b76c-e4d12bf3e5f6",
+                  "license-expiring": "/api/3/picklists/c61d5134-e24f-448a-a2c0-d1e4d2352268",
+                  "field-mismatch": "/api/3/picklists/e42f12d5-ed5c-43ee-b8d2-f2a314a32a2f",
+              }
+              ka = {r["serial"]: r for r in a}
+              kb = {r["serial"]: r for r in b}
+              matched = len(set(ka) & set(kb))
+              findings = []
+              for s, r in ka.items():
+                  if s not in kb:
+                      findings.append({"join_key": s, "mismatch_type": MT["missing-in-B"],
+                                       "source_system": "FortiCloud", "target_system": "ServiceNow",
+                                       "source_id": s, "target_id": "",
+                                       "details": f"{r['name']} present in FortiCloud, missing in ServiceNow CMDB"})
+                  elif r.get("license") == "expired":
+                      findings.append({"join_key": s, "mismatch_type": MT["license-expiring"],
+                                       "source_system": "FortiCloud", "target_system": "ServiceNow",
+                                       "source_id": s, "target_id": s,
+                                       "details": f"{r['name']} is decommissioned/expired in FortiCloud"})
+              for s, r in kb.items():
+                  if s not in ka:
+                      # source_id is a required field; the serial is the shared key,
+                      # so use it even though there is no FortiCloud-side record.
+                      findings.append({"join_key": s, "mismatch_type": MT["missing-in-A"],
+                                       "source_system": "FortiCloud", "target_system": "ServiceNow",
+                                       "source_id": s, "target_id": s,
+                                       "details": f"{r['name']} present in ServiceNow CMDB, missing in FortiCloud"})
 
-            # MismatchType picklist IRIs (resolved at DEPLOY time; create_record
-            # needs IRIs, not friendly values). RE-RESOLVE after the
-            # reconciliation_results module + picklists are (re)created.
-            MT = {
-                "missing-in-A": "/api/3/picklists/26399476-3fbf-4443-8240-a374c988126e",
-                "missing-in-B": "/api/3/picklists/2b7b652f-3e22-4f52-b76c-e4d12bf3e5f6",
-                "license-expiring": "/api/3/picklists/c61d5134-e24f-448a-a2c0-d1e4d2352268",
-                "field-mismatch": "/api/3/picklists/e42f12d5-ed5c-43ee-b8d2-f2a314a32a2f",
-            }
-            mt_label = {v: k for k, v in MT.items()}  # IRI -> friendly label, for the CSV
+              # Per-type severity + emoji (single channel, differentiated alerts)
+              # and a human label for the summary / CSV.
+              mt_rev = {v: k for k, v in MT.items()}  # IRI -> friendly key
+              SEV = {"license-expiring": ("\U0001F534", "HIGH"),
+                     "missing-in-B":     ("\U0001F7E1", "MEDIUM"),
+                     "field-mismatch":   ("\U0001F7E0", "MEDIUM"),
+                     "missing-in-A":     ("⚪", "LOW")}
+              LABELS = {"license-expiring": "Decommissioned / expiring",
+                        "missing-in-B": "Missing in ServiceNow CMDB",
+                        "field-mismatch": "Field mismatch",
+                        "missing-in-A": "Stale CMDB (not in FortiCloud)"}
+              counts = {}
+              for f in findings:
+                  kind = mt_rev.get(f["mismatch_type"], "field-mismatch")
+                  emoji, sev = SEV.get(kind, ("\U0001F7E0", "MEDIUM"))
+                  f["kind"], f["emoji"], f["severity"] = kind, emoji, sev
+                  counts[kind] = counts.get(kind, 0) + 1
 
-            # Findings = issues, each keyed by join_key + mismatch_type (so a serial
-            # can carry several distinct findings without colliding).
-            findings = []
-            for s, r in a.items():
-                if s not in b:
-                    findings.append({"issue_key": s + "|missing-in-B", "join_key": s,
-                                     "mismatch_type": MT["missing-in-B"],
-                                     "source_system": "FortiCloud", "target_system": "ServiceNow",
-                                     "source_id": s, "target_id": "",
-                                     "details": f"{r['name']} present in FortiCloud, missing in ServiceNow CMDB"})
-                elif r.get("source_a") == "decommissioned":
-                    findings.append({"issue_key": s + "|license-expiring", "join_key": s,
-                                     "mismatch_type": MT["license-expiring"],
-                                     "source_system": "FortiCloud", "target_system": "ServiceNow",
-                                     "source_id": s, "target_id": s,
-                                     "details": f"{r['name']} is decommissioned/expired in FortiCloud"})
-            for s, r in b.items():
-                if s not in a:
-                    findings.append({"issue_key": s + "|missing-in-A", "join_key": s,
-                                     "mismatch_type": MT["missing-in-A"],
-                                     "source_system": "FortiCloud", "target_system": "ServiceNow",
-                                     "source_id": "", "target_id": s,
-                                     "details": f"{r['name']} present in ServiceNow CMDB, missing in FortiCloud"})
+              # Human CSV (for the email body).
+              buf = io.StringIO()
+              w = csv.writer(buf)
+              w.writerow(["join_key", "severity", "mismatch_type", "source_system", "target_system", "details"])
+              for f in findings:
+                  w.writerow([f["join_key"], f["severity"], f["kind"],
+                              f["source_system"], f["target_system"], f["details"]])
 
-            buf = io.StringIO()
-            w = csv.writer(buf)
-            w.writerow(["join_key", "mismatch_type", "source_system", "target_system", "details"])
-            for f in findings:
-                w.writerow([f["join_key"], mt_label.get(f["mismatch_type"], f["mismatch_type"]),
-                            f["source_system"], f["target_system"], f["details"]])
-            # Module-level exec: no `return`, no `open`. print(json.dumps(...)) ->
-            # the connector auto-deserializes this into a structured code_output dict.
-            print(json.dumps({"assets": assets, "findings": findings,
-                              "csv_content": buf.getvalue(),
-                              "fc_count": len(a), "sn_count": len(b),
-                              "count": len(findings)}))
+              # Big summary view — native Slack Block Kit (header + context +
+              # two-column field grids). Returned as a JSON string for the slack
+              # connector's `blocks` param.
+              today = datetime.date.today().strftime("%b %d")
+              def fld(label, val):
+                  return {"type": "mrkdwn", "text": f"*{label}*\n{val}"}
+              blocks = [
+                  {"type": "header", "text": {"type": "plain_text", "text": "CMDB Reconciliation"}},
+                  {"type": "context", "elements": [
+                      {"type": "mrkdwn", "text": f"FortiCloud ⇄ ServiceNow · {today}"}]},
+                  {"type": "divider"},
+                  {"type": "section", "fields": [
+                      fld("Assets", len(a)), fld("Matched", matched),
+                      fld("Issues", len(findings)), fld("In CMDB", len(b))]},
+              ]
+              type_fields = []
+              for kind in ["license-expiring", "missing-in-B", "missing-in-A", "field-mismatch"]:
+                  n = counts.get(kind, 0)
+                  if n:
+                      type_fields.append(fld(LABELS[kind], n))
+              if type_fields:
+                  blocks.append({"type": "divider"})
+                  blocks.append({"type": "section", "fields": type_fields})
+              summary_blocks = json.dumps(blocks)
 
-      # --- Upsert every asset (idempotent by join_key) -----------------------
-      # is_upsert -> /api/3/upsert/recon_assets + operation: Overwrite; sourceId
-      # is the natural key, so a re-run updates the existing asset row, not a dup.
-      - name: Upsert assets
-        type: create_record
-        next: Upsert issues
-        for_each:
-          item: "{{ vars.steps.Reconcile.data.code_output.assets }}"
-        arguments:
-          module: recon_assets
-          is_upsert: true
-          resource:
-            sourceId: "{{ vars.item.join_key }}"
-            join_key: "{{ vars.item.join_key }}"
-            name: "{{ vars.item.name }}"
-            source_a: "{{ vars.item.source_a }}"
-            source_b: "{{ vars.item.source_b }}"
+              # Write the CSV to disk on the appliance so the email step can attach
+              # it (code-runner has unrestricted open(); the smtp connector runs on
+              # the same host and reads file_path).
+              csv_path = "/tmp/cmdb_reconciliation_report.csv"
+              try:
+                  with open(csv_path, "w") as fh:
+                      fh.write(buf.getvalue())
+              except Exception:
+                  csv_path = ""
+              # Plain-text fallback (Slack notification preview + email-safe).
+              summary_text = (f"CMDB Reconciliation - {today}: {len(a)} assets, "
+                              f"{matched} matched, {len(findings)} issues")
 
-      # --- Upsert every finding as an issue (idempotent by issue_key) --------
-      # The `asset` lookup relationship is left unset in v1 (link = join_key
-      # string); populating it needs the find_record -> IRI map (v2 follow-up).
-      - name: Upsert issues
+              return {"findings": findings,
+                      "first": findings[0] if findings else None,
+                      "csv_content": buf.getvalue(),
+                      "summary_text": summary_text,
+                      "summary_blocks": summary_blocks,
+                      "csv_path": csv_path,
+                      "counts": counts,
+                      "fc_count": len(a), "sn_count": len(b),
+                      "matched": matched,
+                      "count": len(findings)}
+
+      # One reconciliation_results record per finding (for_each over the findings
+      # array) — so dashboards can group/filter by mismatch_type, status, etc.
+      # NOTE: without a module uniqueness constraint on (join_key, mismatch_type)
+      # this re-creates records every run; add that constraint for true upsert.
+      - name: Write finding
         type: create_record
         next: Email report
         for_each:
           item: "{{ vars.steps.Reconcile.data.code_output.findings }}"
         arguments:
-          module: recon_issues
-          is_upsert: true
+          module: reconciliation_results
+          operation: Create
           resource:
-            sourceId: "{{ vars.item.issue_key }}"
-            issue_key: "{{ vars.item.issue_key }}"
+            source_system: "{{ vars.item.source_system }}"
+            source_id: "{{ vars.item.source_id }}"
+            target_system: "{{ vars.item.target_system }}"
+            target_id: "{{ vars.item.target_id }}"
             join_key: "{{ vars.item.join_key }}"
             mismatch_type: "{{ vars.item.mismatch_type }}"
-            # ReconStatus picklist IRI for "Open" (resolved at deploy time; create_record
-            # needs an IRI, not the friendly value "Open"). RE-RESOLVE after module rebuild.
+            # ReconStatus picklist IRI for "Open" (create_record needs an IRI).
             status: "/api/3/picklists/58200b01-3cca-4b6b-a3c3-a83415def3e2"
-            source_system: "{{ vars.item.source_system }}"
-            target_system: "{{ vars.item.target_system }}"
-            source_id: "{{ vars.item.source_id }}"
-            target_id: "{{ vars.item.target_id }}"
             details: "{{ vars.item.details }}"
+          step_variables: []
+
+      # One Slack message per flagged device issue, to #it-asset-mgmt.
+      - name: Slack alert
+        type: connector
+        next: Slack summary
+        for_each:
+          item: "{{ vars.steps.Reconcile.data.code_output.findings }}"
+        arguments:
+          connector: slack
+          operation: send_message
+          config: slack
+          params:
+            channel: "#it-asset-mgmt"
+            message: "{{ vars.item.emoji }} *{{ vars.item.severity }}* — {{ vars.item.details }} (asset {{ vars.item.join_key }}, {{ vars.item.source_system }} vs {{ vars.item.target_system }})"
+            # The connector defaults thread_ts to 0 (Slack rejects it) unless sent
+            # explicitly empty — post as a top-level message, not a thread reply.
+            thread_ts: ""
+
+      # Big summary view — native Block Kit (header + field grids).
+      - name: Slack summary
+        type: connector
+        arguments:
+          connector: slack
+          operation: send_message
+          config: slack
+          params:
+            channel: "#it-asset-mgmt"
+            message: "{{ vars.steps.Reconcile.data.code_output.summary_text }}"
+            blocks: "{{ vars.steps.Reconcile.data.code_output.summary_blocks }}"
+            thread_ts: ""
 
       - name: Email report
         type: connector
+        next: Slack alert
         arguments:
           connector: smtp
           operation: send_email
           config: localhost-postfix
           params:
             to: "root@localhost"
-            subject: "Reconciliation Report - {{ vars.steps.Reconcile.data.code_output.count }} findings (FortiCloud {{ vars.steps.Reconcile.data.code_output.fc_count }} vs ServiceNow {{ vars.steps.Reconcile.data.code_output.sn_count }})"
-            body: "Reconciliation report ({{ vars.steps.Reconcile.data.code_output.count }} findings):\n\nFortiCloud assets: {{ vars.steps.Reconcile.data.code_output.fc_count }}\nServiceNow CIs (with serial): {{ vars.steps.Reconcile.data.code_output.sn_count }}\n\n{{ vars.steps.Reconcile.data.code_output.csv_content }}"
+            subject: "Reconciliation Report - {{ vars.steps.Reconcile.data.code_output.matched }} matched, {{ vars.steps.Reconcile.data.code_output.count }} findings (FortiCloud {{ vars.steps.Reconcile.data.code_output.fc_count }} vs ServiceNow {{ vars.steps.Reconcile.data.code_output.sn_count }})"
+            body: "Reconciliation report:\n\nFortiCloud assets: {{ vars.steps.Reconcile.data.code_output.fc_count }}\nServiceNow CMDB CIs: {{ vars.steps.Reconcile.data.code_output.sn_count }}\nMatched: {{ vars.steps.Reconcile.data.code_output.matched }}\nDiscrepancies: {{ vars.steps.Reconcile.data.code_output.count }}\n\nFull breakdown attached (cmdb_reconciliation_report.csv)."
             content_type: "text"
+            # Attach the CSV the Reconcile step wrote to the appliance.
+            file_path: "{{ vars.steps.Reconcile.data.code_output.csv_path }}"
+            file_name: "cmdb_reconciliation_report.csv"


### PR DESCRIPTION
Switches the Reconcile step in `scripts/archetype_pilot_reconcile_and_report.yaml` from a sandboxed `code_snippet` to the custom code-runner connector (unrestricted Python: set/sum/imports/return all work; `return <dict>` → `vars.steps.Reconcile.data.code_output`). Emits one reconciliation record per finding for dashboard groupability.

**Note:** code-runner is a custom connector not in the connector baseline, so this script needs `--refresh-catalog` to compile/deploy. It's a local script in `scripts/`, not CI-gated.

This was the uncommitted WIP recovered during the local main sync after PR #33 merged.